### PR TITLE
feat: AI Demo Director (MCP) — agent-driven cinematic demo generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ dist-ssr
 /recordings
 /scratch
 
+# Local MCP config (machine-specific absolute paths; see docs/AI_DEMO_DIRECTOR.md)
+/.mcp.json
+
 # Editor / OS
 .DS_Store
 Thumbs.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,6 +5409,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "vuoom-input",
+ "windows 0.60.0",
  "windows-capture",
 ]
 
@@ -5499,6 +5500,7 @@ version = "0.1.30"
 dependencies = [
  "glam",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,12 +1255,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1328,6 +1344,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2962,6 +2979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,6 +3512,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,7 +3708,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3675,8 +3733,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3686,6 +3746,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5320,6 +5392,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "vuoom-capture",
+ "vuoom-control",
  "vuoom-encode",
  "vuoom-input",
  "vuoom-preview",
@@ -5361,6 +5434,19 @@ dependencies = [
  "tracing",
  "vuoom-zoom",
  "windows 0.60.0",
+]
+
+[[package]]
+name = "vuoom-mcp"
+version = "0.1.27"
+dependencies = [
+ "anyhow",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "vuoom-control",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "base64 0.22.1",
  "glam",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-capture"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -5413,8 +5413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "vuoom-control"
+version = "0.1.30"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "vuoom-encode"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "color_quant",
  "gif",
@@ -5427,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-input"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "glam",
  "thiserror 2.0.18",
@@ -5438,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-mcp"
-version = "0.1.27"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -5451,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-preview"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "futures-util",
  "thiserror 2.0.18",
@@ -5462,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-project"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "glam",
  "serde",
@@ -5472,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-render"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "bytemuck",
  "glam",
@@ -5487,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-zoom"
-version = "0.1.28"
+version = "0.1.30"
 dependencies = [
  "glam",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/vuoom-project",
     "crates/vuoom-preview",
     "crates/vuoom-control",
+    "crates/vuoom-mcp",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/vuoom-encode",
     "crates/vuoom-project",
     "crates/vuoom-preview",
+    "crates/vuoom-control",
 ]
 
 [workspace.package]
@@ -33,6 +34,7 @@ vuoom-render  = { path = "crates/vuoom-render" }
 vuoom-encode  = { path = "crates/vuoom-encode" }
 vuoom-project = { path = "crates/vuoom-project" }
 vuoom-preview = { path = "crates/vuoom-preview" }
+vuoom-control = { path = "crates/vuoom-control" }
 
 # Third-party (versions are starting points — confirm latest when first pulled)
 serde       = { version = "1", features = ["derive"] }

--- a/crates/vuoom-capture/Cargo.toml
+++ b/crates/vuoom-capture/Cargo.toml
@@ -13,3 +13,10 @@ tracing.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-capture = "2"
+# Window enumeration + DWM extended-frame bounds for window-targeted capture. Pinned to 0.60
+# to match the rest of the workspace (vuoom-input, src-tauri) and windows-capture's own tree.
+windows = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Dwm",
+    "Win32_UI_WindowsAndMessaging",
+] }

--- a/crates/vuoom-capture/src/capture.rs
+++ b/crates/vuoom-capture/src/capture.rs
@@ -15,8 +15,9 @@ use windows_capture::graphics_capture_api::{GraphicsCaptureApi, InternalCaptureC
 use windows_capture::monitor::Monitor;
 use windows_capture::settings::{
     ColorFormat, CursorCaptureSettings, DirtyRegionSettings, DrawBorderSettings,
-    MinimumUpdateIntervalSettings, SecondaryWindowSettings, Settings,
+    GraphicsCaptureItemType, MinimumUpdateIntervalSettings, SecondaryWindowSettings, Settings,
 };
+use windows_capture::window::Window;
 
 /// One captured frame: tightly-packed BGRA8 pixels + dimensions + QPC timestamp.
 pub struct CapturedFrame {
@@ -33,6 +34,15 @@ pub struct CropRegion {
     pub y: u32,
     pub w: u32,
     pub h: u32,
+}
+
+/// What to capture: a display monitor or a specific application window.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CaptureTarget {
+    /// A display monitor by Win32 device name (e.g. `\\.\DISPLAY2`); `None` = primary.
+    Monitor { device_name: Option<String> },
+    /// A top-level window whose title *contains* `title` (case-insensitive, best/topmost match).
+    Window { title: String },
 }
 
 /// Clamp a requested crop inside the frame, guaranteeing a non-empty rect.
@@ -106,6 +116,11 @@ impl GraphicsCaptureApiHandler for Handler {
             control.stop();
             return Ok(());
         }
+        // Dimensions are read fresh every frame, so a window that RESIZES mid-capture is
+        // handled without crashing: WGC hands us a new frame size and `clamp_region`
+        // re-clamps the crop to whatever the current frame is (the crop is clamped/"letterboxed"
+        // into the live frame rather than being a fixed absolute rect). Frames therefore keep
+        // flowing at the new size; downstream consumers see a dimension change.
         let width = frame.width();
         let height = frame.height();
         let buffer = frame.buffer()?;
@@ -143,18 +158,29 @@ fn pick_monitor(name: Option<&str>) -> Result<Monitor, CaptureError> {
     Monitor::primary().map_err(|e| CaptureError::Start(e.to_string()))
 }
 
-/// Capture one display (by device name; primary if `None`), **blocking** until stopped;
-/// BGRA frames go to `tx`.
+/// Resolve a window by case-insensitive title substring, picking the best/topmost match.
+fn pick_window(title: &str) -> Result<Window, CaptureError> {
+    let windows =
+        Window::enumerate().map_err(|e| CaptureError::Start(format!("enumerate windows: {e}")))?;
+    let titles: Vec<String> = windows
+        .iter()
+        .map(|w| w.title().unwrap_or_default())
+        .collect();
+    let idx = crate::windows::best_match_index(&titles, title)
+        .ok_or_else(|| CaptureError::Start(format!("no window matching '{title}'")))?;
+    Ok(windows[idx])
+}
+
+/// Build capture settings for `item` and run the session, **blocking** until stopped.
 ///
-/// # Errors
-/// Returns [`CaptureError`] if the monitor or capture session cannot be started.
-pub fn run_display(
+/// Generic over the capture item so the monitor and window paths share one code path (both
+/// `Monitor` and `Window` implement `TryInto<GraphicsCaptureItemType>`).
+fn run_capture<T: TryInto<GraphicsCaptureItemType>>(
+    item: T,
     tx: Sender<CapturedFrame>,
     stop: Arc<AtomicBool>,
     crop: Option<CropRegion>,
-    monitor: Option<&str>,
 ) -> Result<(), CaptureError> {
-    let monitor = pick_monitor(monitor)?;
     // Capture without the OS "being captured" highlight where the platform allows it
     // (Windows 11+, via the `IsBorderRequired` API). On Windows 10 that API is absent and the
     // border can't be removed, so we fall back to Default — requesting a specific value there
@@ -165,7 +191,7 @@ pub fn run_display(
         DrawBorderSettings::Default
     };
     let settings = Settings::new(
-        monitor,
+        item,
         CursorCaptureSettings::Default,
         border,
         SecondaryWindowSettings::Default,
@@ -176,6 +202,52 @@ pub fn run_display(
     );
     Handler::start(settings).map_err(|e| CaptureError::Start(e.to_string()))?;
     Ok(())
+}
+
+/// Capture a [`CaptureTarget`] (monitor or window), **blocking** until stopped; BGRA frames
+/// go to `tx`. `crop`, when set, is applied relative to the captured frame (monitor- or
+/// window-relative physical px) and re-clamped every frame, so a window that resizes
+/// mid-capture is handled safely (see `Handler::on_frame_arrived`).
+///
+/// # Errors
+/// Returns [`CaptureError`] if the target cannot be resolved or the session cannot start.
+pub fn run_target(
+    tx: Sender<CapturedFrame>,
+    stop: Arc<AtomicBool>,
+    crop: Option<CropRegion>,
+    target: &CaptureTarget,
+) -> Result<(), CaptureError> {
+    match target {
+        CaptureTarget::Monitor { device_name } => {
+            let monitor = pick_monitor(device_name.as_deref())?;
+            run_capture(monitor, tx, stop, crop)
+        }
+        CaptureTarget::Window { title } => {
+            let window = pick_window(title)?;
+            run_capture(window, tx, stop, crop)
+        }
+    }
+}
+
+/// Capture one display (by device name; primary if `None`), **blocking** until stopped;
+/// BGRA frames go to `tx`. Thin wrapper over [`run_target`] for the monitor case.
+///
+/// # Errors
+/// Returns [`CaptureError`] if the monitor or capture session cannot be started.
+pub fn run_display(
+    tx: Sender<CapturedFrame>,
+    stop: Arc<AtomicBool>,
+    crop: Option<CropRegion>,
+    monitor: Option<&str>,
+) -> Result<(), CaptureError> {
+    run_target(
+        tx,
+        stop,
+        crop,
+        &CaptureTarget::Monitor {
+            device_name: monitor.map(str::to_string),
+        },
+    )
 }
 
 /// Spawn display capture on a background thread; returns the frame receiver and a
@@ -194,6 +266,27 @@ pub fn spawn_region(
     };
     std::thread::spawn(move || {
         if let Err(e) = run_display(tx, stop, crop, monitor.as_deref()) {
+            tracing::error!("screen capture stopped: {e}");
+        }
+    });
+    (rx, handle)
+}
+
+/// Spawn capture of an arbitrary [`CaptureTarget`] (monitor or window) on a background thread;
+/// returns the frame receiver and a [`CaptureHandle`] to stop it. When `crop` is set, frames
+/// are cropped to that sub-rectangle (target-relative physical px) before being sent.
+#[must_use]
+pub fn spawn_target(
+    target: CaptureTarget,
+    crop: Option<CropRegion>,
+) -> (Receiver<CapturedFrame>, CaptureHandle) {
+    let (tx, rx) = channel();
+    let stop = Arc::new(AtomicBool::new(false));
+    let handle = CaptureHandle {
+        stop: Arc::clone(&stop),
+    };
+    std::thread::spawn(move || {
+        if let Err(e) = run_target(tx, stop, crop, &target) {
             tracing::error!("screen capture stopped: {e}");
         }
     });

--- a/crates/vuoom-capture/src/lib.rs
+++ b/crates/vuoom-capture/src/lib.rs
@@ -8,8 +8,13 @@
 #[cfg(windows)]
 mod capture;
 
+/// Top-level window enumeration + bounds (window-targeted capture support).
+pub mod windows;
+
 #[cfg(windows)]
 pub use capture::{
-    run_display, spawn_primary_display, spawn_region, CaptureError, CaptureHandle, CapturedFrame,
-    CropRegion,
+    run_display, run_target, spawn_primary_display, spawn_region, spawn_target, CaptureError,
+    CaptureHandle, CaptureTarget, CapturedFrame, CropRegion,
 };
+
+pub use windows::{find_window_bounds, list_windows, WindowInfo};

--- a/crates/vuoom-capture/src/windows.rs
+++ b/crates/vuoom-capture/src/windows.rs
@@ -1,0 +1,212 @@
+//! Top-level window enumeration + bounds, for window-targeted capture.
+//!
+//! `list_windows` enumerates visible, titled, non-tool top-level app windows in Z-order
+//! (topmost first) with their **physical-pixel** screen rectangles. Bounds come from
+//! `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)` (the true composited frame, which
+//! excludes the invisible resize-border padding that `GetWindowRect` includes), falling back
+//! to `GetWindowRect` when DWM is unavailable. `find_window_bounds` picks the best match for a
+//! case-insensitive title substring. Compile-verified on CI; runtime needs a real desktop.
+
+#[cfg(windows)]
+use std::ffi::c_void;
+
+/// A top-level window's title and physical-pixel screen rectangle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowInfo {
+    pub title: String,
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Pick the best index in `titles` for a case-insensitive `needle` substring.
+///
+/// Preference order: (1) an exact case-insensitive title match; otherwise (2) among titles
+/// that *contain* the needle, the shortest title (the "tightest" match), breaking ties by
+/// lowest index — and since callers pass titles in Z-order, that means the topmost window.
+/// Returns `None` when nothing matches. Pure — unit-tested below.
+pub(crate) fn best_match_index(titles: &[String], needle: &str) -> Option<usize> {
+    let needle_l = needle.to_lowercase();
+    if needle_l.is_empty() {
+        return None;
+    }
+    if let Some(i) = titles.iter().position(|t| t.to_lowercase() == needle_l) {
+        return Some(i);
+    }
+    titles
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.to_lowercase().contains(&needle_l))
+        .min_by_key(|(i, t)| (t.chars().count(), *i))
+        .map(|(i, _)| i)
+}
+
+/// Enumerate visible, titled, non-tool top-level application windows (topmost first).
+#[cfg(windows)]
+#[must_use]
+pub fn list_windows() -> Vec<WindowInfo> {
+    // Leading `::` — the extern crate `windows`, not this `crate::windows` module.
+    use ::windows::core::BOOL;
+    use ::windows::Win32::Foundation::{HWND, LPARAM, RECT, TRUE};
+    use ::windows::Win32::Graphics::Dwm::{
+        DwmGetWindowAttribute, DWMWA_CLOAKED, DWMWA_EXTENDED_FRAME_BOUNDS,
+    };
+    use ::windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
+        IsWindowVisible, GWL_EXSTYLE, WS_EX_TOOLWINDOW,
+    };
+
+    // Physical-pixel bounds: prefer the DWM extended frame (excludes the invisible resize
+    // border), fall back to GetWindowRect.
+    unsafe fn window_rect(hwnd: HWND) -> Option<RECT> {
+        let mut r = RECT::default();
+        let dwm = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            std::ptr::addr_of_mut!(r).cast::<c_void>(),
+            u32::try_from(std::mem::size_of::<RECT>()).unwrap(),
+        );
+        if dwm.is_ok() {
+            return Some(r);
+        }
+        if GetWindowRect(hwnd, &mut r).is_ok() {
+            return Some(r);
+        }
+        None
+    }
+
+    unsafe fn is_cloaked(hwnd: HWND) -> bool {
+        let mut cloaked: u32 = 0;
+        let ok = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAKED,
+            std::ptr::addr_of_mut!(cloaked).cast::<c_void>(),
+            u32::try_from(std::mem::size_of::<u32>()).unwrap(),
+        );
+        ok.is_ok() && cloaked != 0
+    }
+
+    unsafe fn title_of(hwnd: HWND) -> String {
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return String::new();
+        }
+        let mut buf = vec![0u16; usize::try_from(len).unwrap() + 1];
+        let copied = GetWindowTextW(hwnd, &mut buf);
+        if copied <= 0 {
+            return String::new();
+        }
+        String::from_utf16_lossy(&buf[..copied as usize])
+    }
+
+    unsafe extern "system" fn callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        // SAFETY: `lparam` carries the &mut Vec<WindowInfo> we passed into EnumWindows.
+        let out = &mut *(lparam.0 as *mut Vec<WindowInfo>);
+
+        if !IsWindowVisible(hwnd).as_bool() {
+            return TRUE;
+        }
+        // Skip tool windows (floating palettes, tooltips, etc.).
+        let ex_styles = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if (ex_styles & isize::try_from(WS_EX_TOOLWINDOW.0).unwrap()) != 0 {
+            return TRUE;
+        }
+        // Skip cloaked windows (e.g. suspended/off-screen UWP shells).
+        if is_cloaked(hwnd) {
+            return TRUE;
+        }
+        let title = title_of(hwnd);
+        if title.is_empty() {
+            return TRUE;
+        }
+        if let Some(r) = window_rect(hwnd) {
+            let w = (r.right - r.left).max(0);
+            let h = (r.bottom - r.top).max(0);
+            if w > 0 && h > 0 {
+                out.push(WindowInfo {
+                    title,
+                    x: r.left,
+                    y: r.top,
+                    w: w as u32,
+                    h: h as u32,
+                });
+            }
+        }
+        TRUE
+    }
+
+    let mut windows: Vec<WindowInfo> = Vec::new();
+    // SAFETY: standard EnumWindows call; the callback only touches the Vec we point at.
+    // EnumWindows visits top-level windows in Z-order (topmost first).
+    unsafe {
+        let _ = EnumWindows(
+            Some(callback),
+            LPARAM(std::ptr::addr_of_mut!(windows) as isize),
+        );
+    }
+    windows
+}
+
+/// Non-Windows stub — the crate is Windows-only but this keeps `cargo check` portable.
+#[cfg(not(windows))]
+#[must_use]
+pub fn list_windows() -> Vec<WindowInfo> {
+    Vec::new()
+}
+
+/// Find the best-matching visible top-level window for a case-insensitive title substring.
+#[must_use]
+pub fn find_window_bounds(title_substring: &str) -> Option<WindowInfo> {
+    let mut windows = list_windows();
+    let titles: Vec<String> = windows.iter().map(|w| w.title.clone()).collect();
+    let idx = best_match_index(&titles, title_substring)?;
+    Some(windows.swap_remove(idx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn titles(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn exact_case_insensitive_match_wins() {
+        let t = titles(&["Some Notepad Thing", "Notepad", "notepad extra"]);
+        assert_eq!(best_match_index(&t, "notepad"), Some(1));
+    }
+
+    #[test]
+    fn substring_picks_shortest_then_topmost() {
+        // No exact match; all contain "code". Shortest title is "VS Code" (idx 2),
+        // but "Code" (idx 3) is shorter still.
+        let t = titles(&[
+            "project - Visual Studio Code",
+            "readme - Visual Studio Code",
+            "VS Code",
+            "Code",
+        ]);
+        assert_eq!(best_match_index(&t, "code"), Some(3));
+    }
+
+    #[test]
+    fn substring_ties_break_to_topmost() {
+        // Two equally-short matches; the earlier (topmost) index wins.
+        let t = titles(&["My App", "My App"]);
+        assert_eq!(best_match_index(&t, "app"), Some(0));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let t = titles(&["Firefox", "Explorer"]);
+        assert_eq!(best_match_index(&t, "chrome"), None);
+    }
+
+    #[test]
+    fn empty_needle_returns_none() {
+        let t = titles(&["Firefox"]);
+        assert_eq!(best_match_index(&t, ""), None);
+    }
+}

--- a/crates/vuoom-control/Cargo.toml
+++ b/crates/vuoom-control/Cargo.toml
@@ -1,0 +1,16 @@
+# Control protocol for the AI Demo Director (MCP). See docs/13-AI-Demo-Director-Research.md.
+# Pure serde types + a tiny blocking TCP client — the contract shared by Vuoom's in-app
+# control server (src-tauri) and the standalone `vuoom-mcp` sidecar. No GPU/OS deps, so it
+# compiles fast and is fully unit-testable off-CI.
+[package]
+name = "vuoom-control"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/vuoom-control/examples/mock_server.rs
+++ b/crates/vuoom-control/examples/mock_server.rs
@@ -11,7 +11,8 @@ use std::net::{TcpListener, TcpStream};
 
 use vuoom_control::{
     write_message, ClipInfo, ControlRequest, ControlResponse, CutSpan, ExportState, FrameShot,
-    RecordState, RecordingSummary, ScreenGeometry, SpeedSpan, StatusInfo, ZoomSpan,
+    PreviewInfo, RecordState, RecordingSummary, RegionRect, ScreenGeometry, SpeedSpan, StatusInfo,
+    WindowRect, ZoomSpan,
 };
 
 /// A 1×1 transparent PNG (base64) — stands in for a sampled frame.
@@ -159,13 +160,35 @@ fn respond(req: ControlRequest) -> ControlResponse {
                 end: 7.5,
             }],
         },
-        ControlRequest::AutoSpeed { factor } => ControlResponse::Speeds {
+        ControlRequest::AutoSpeed { factor, .. } => ControlResponse::Speeds {
             speeds: vec![SpeedSpan {
                 start: 2.0,
                 end: 3.5,
                 factor,
             }],
         },
+        ControlRequest::PreviewClip { .. } => ControlResponse::Preview(PreviewInfo {
+            gif_base64: TINY_PNG.into(),
+            frame_count: 10,
+            width: 480,
+            height: 270,
+            duration: 2.0,
+        }),
+        ControlRequest::ListWindows => ControlResponse::Windows {
+            windows: vec![WindowRect {
+                title: "Mock Window".into(),
+                x: 100,
+                y: 80,
+                w: 1280,
+                h: 720,
+            }],
+        },
+        ControlRequest::SetRegionToWindow { .. } => ControlResponse::Region(RegionRect {
+            x: 100,
+            y: 80,
+            w: 1280,
+            h: 720,
+        }),
         ControlRequest::ExportGif { .. } | ControlRequest::ExportMp4 { .. } => {
             ControlResponse::Job { id: 1 }
         }

--- a/crates/vuoom-control/examples/mock_server.rs
+++ b/crates/vuoom-control/examples/mock_server.rs
@@ -1,0 +1,99 @@
+//! A mock Vuoom control server for testing the `vuoom-mcp` sidecar without the full app.
+//!
+//! It speaks the real [`vuoom_control`] protocol over a `127.0.0.1` port and writes the
+//! discovery file, so the sidecar connects to it exactly as it would to Vuoom — but it returns
+//! canned responses instead of recording. Lets the whole agent → MCP → protocol path be
+//! exercised on any machine (no GPU/capture). Run: `cargo run -p vuoom-control --example mock_server`.
+
+use std::io::{BufRead, BufReader};
+use std::net::{TcpListener, TcpStream};
+
+use vuoom_control::{
+    write_message, ClipInfo, ControlRequest, ControlResponse, FrameShot, RecordingSummary,
+    ScreenGeometry,
+};
+
+/// A 1×1 transparent PNG (base64) — stands in for a sampled frame.
+const TINY_PNG: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+fn main() -> std::io::Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    vuoom_control::write_port_file(port)?;
+    eprintln!("mock control server: listening on 127.0.0.1:{port}");
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => serve(s),
+            Err(e) => eprintln!("mock: accept failed: {e}"),
+        }
+    }
+    Ok(())
+}
+
+fn serve(stream: TcpStream) {
+    let Ok(mut writer) = stream.try_clone() else {
+        return;
+    };
+    let reader = BufReader::new(stream);
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let resp = match serde_json::from_str::<ControlRequest>(&line) {
+            Ok(req) => respond(req),
+            Err(e) => ControlResponse::error(format!("bad request: {e}")),
+        };
+        if write_message(&mut writer, &resp).is_err() {
+            break;
+        }
+    }
+}
+
+/// Canned replies covering every request variant.
+fn respond(req: ControlRequest) -> ControlResponse {
+    match req {
+        ControlRequest::Ping
+        | ControlRequest::SetRegion { .. }
+        | ControlRequest::SetZoomAmount { .. }
+        | ControlRequest::StartRecording
+        | ControlRequest::SetPaused { .. }
+        | ControlRequest::MoveCursor { .. }
+        | ControlRequest::Click { .. }
+        | ControlRequest::TypeText { .. }
+        | ControlRequest::KeyChord { .. }
+        | ControlRequest::Scroll { .. }
+        | ControlRequest::Seek { .. }
+        | ControlRequest::ExportGif { .. }
+        | ControlRequest::ExportMp4 { .. } => ControlResponse::Ok,
+        ControlRequest::ScreenGeometry => ControlResponse::Geometry(ScreenGeometry {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+        }),
+        ControlRequest::StopRecording => ControlResponse::Recording(RecordingSummary {
+            duration: 3.0,
+            frames: 180,
+            zooms: 2,
+        }),
+        ControlRequest::ClipState => ControlResponse::Clip(ClipInfo {
+            duration: 3.0,
+            zooms: 2,
+            cuts: 0,
+            speed_regions: 1,
+        }),
+        ControlRequest::GetFrames { times, .. } => ControlResponse::Frames {
+            frames: times
+                .into_iter()
+                .map(|t| FrameShot {
+                    t,
+                    width: 1,
+                    height: 1,
+                    png_base64: TINY_PNG.to_string(),
+                })
+                .collect(),
+        },
+        ControlRequest::EstimateGif { .. } => ControlResponse::Size { bytes: 1_234_567 },
+    }
+}

--- a/crates/vuoom-control/examples/mock_server.rs
+++ b/crates/vuoom-control/examples/mock_server.rs
@@ -56,6 +56,7 @@ fn respond(req: ControlRequest) -> ControlResponse {
         ControlRequest::Ping
         | ControlRequest::SetRegion { .. }
         | ControlRequest::SetZoomAmount { .. }
+        | ControlRequest::SetAutoZoomOnClick { .. }
         | ControlRequest::StartRecording
         | ControlRequest::SetPaused { .. }
         | ControlRequest::MoveCursor { .. }

--- a/crates/vuoom-control/examples/mock_server.rs
+++ b/crates/vuoom-control/examples/mock_server.rs
@@ -1,16 +1,17 @@
 //! A mock Vuoom control server for testing the `vuoom-mcp` sidecar without the full app.
 //!
 //! It speaks the real [`vuoom_control`] protocol over a `127.0.0.1` port and writes the
-//! discovery file, so the sidecar connects to it exactly as it would to Vuoom — but it returns
-//! canned responses instead of recording. Lets the whole agent → MCP → protocol path be
-//! exercised on any machine (no GPU/capture). Run: `cargo run -p vuoom-control --example mock_server`.
+//! discovery file (port + auth token), so the sidecar connects to it exactly as it would to
+//! Vuoom — but it returns canned responses instead of recording. Lets the whole agent → MCP
+//! → protocol path be exercised on any machine (no GPU/capture).
+//! Run: `cargo run -p vuoom-control --example mock_server`.
 
 use std::io::{BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
 
 use vuoom_control::{
-    write_message, ClipInfo, ControlRequest, ControlResponse, FrameShot, RecordingSummary,
-    ScreenGeometry,
+    write_message, ClipInfo, ControlRequest, ControlResponse, CutSpan, ExportState, FrameShot,
+    RecordState, RecordingSummary, ScreenGeometry, SpeedSpan, StatusInfo, ZoomSpan,
 };
 
 /// A 1×1 transparent PNG (base64) — stands in for a sampled frame.
@@ -19,22 +20,29 @@ const TINY_PNG: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4
 fn main() -> std::io::Result<()> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     let port = listener.local_addr()?.port();
-    vuoom_control::write_port_file(port)?;
+    let token = vuoom_control::generate_token();
+    vuoom_control::write_port_file(port, &token)?;
     eprintln!("mock control server: listening on 127.0.0.1:{port}");
     for stream in listener.incoming() {
         match stream {
-            Ok(s) => serve(s),
+            Ok(s) => serve(s, &token),
             Err(e) => eprintln!("mock: accept failed: {e}"),
         }
     }
     Ok(())
 }
 
-fn serve(stream: TcpStream) {
+fn serve(stream: TcpStream, token: &str) {
     let Ok(mut writer) = stream.try_clone() else {
         return;
     };
-    let reader = BufReader::new(stream);
+    let mut reader = BufReader::new(stream);
+    // First line must be the auth token, exactly like the real server.
+    let mut auth = String::new();
+    if reader.read_line(&mut auth).is_err() || auth.trim() != token {
+        eprintln!("mock: rejected connection (bad token)");
+        return;
+    }
     for line in reader.lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
@@ -50,28 +58,57 @@ fn serve(stream: TcpStream) {
     }
 }
 
+fn mock_zooms() -> Vec<ZoomSpan> {
+    vec![
+        ZoomSpan {
+            start: 0.5,
+            end: 2.0,
+            amount: 1.8,
+            focus: None,
+        },
+        ZoomSpan {
+            start: 4.0,
+            end: 6.0,
+            amount: 1.8,
+            focus: Some((0.3, 0.6)),
+        },
+    ]
+}
+
 /// Canned replies covering every request variant.
 fn respond(req: ControlRequest) -> ControlResponse {
     match req {
         ControlRequest::Ping
         | ControlRequest::SetRegion { .. }
         | ControlRequest::SetZoomAmount { .. }
-        | ControlRequest::SetAutoZoomOnClick { .. }
-        | ControlRequest::StartRecording
+        | ControlRequest::SetZoomStyle { .. }
+        | ControlRequest::StartRecording { .. }
+        | ControlRequest::CancelRecording
         | ControlRequest::SetPaused { .. }
         | ControlRequest::MoveCursor { .. }
         | ControlRequest::Click { .. }
+        | ControlRequest::Drag { .. }
         | ControlRequest::TypeText { .. }
         | ControlRequest::KeyChord { .. }
         | ControlRequest::Scroll { .. }
         | ControlRequest::Seek { .. }
-        | ControlRequest::ExportGif { .. }
-        | ControlRequest::ExportMp4 { .. } => ControlResponse::Ok,
+        | ControlRequest::ClearSpeed
+        | ControlRequest::SetTrim { .. } => ControlResponse::Ok,
         ControlRequest::ScreenGeometry => ControlResponse::Geometry(ScreenGeometry {
             x: 0,
             y: 0,
             width: 1920,
             height: 1080,
+        }),
+        ControlRequest::Screenshot { .. } => ControlResponse::Shot(FrameShot {
+            t: 0.0,
+            width: 1,
+            height: 1,
+            png_base64: TINY_PNG.to_string(),
+        }),
+        ControlRequest::Status => ControlResponse::Status(StatusInfo {
+            state: RecordState::Idle,
+            elapsed: None,
         }),
         ControlRequest::StopRecording => ControlResponse::Recording(RecordingSummary {
             duration: 3.0,
@@ -79,10 +116,18 @@ fn respond(req: ControlRequest) -> ControlResponse {
             zooms: 2,
         }),
         ControlRequest::ClipState => ControlResponse::Clip(ClipInfo {
-            duration: 3.0,
-            zooms: 2,
-            cuts: 0,
-            speed_regions: 1,
+            duration: 8.0,
+            output_duration: 7.0,
+            zooms: mock_zooms(),
+            cuts: vec![CutSpan {
+                start: 6.5,
+                end: 7.5,
+            }],
+            speeds: vec![SpeedSpan {
+                start: 2.0,
+                end: 3.5,
+                factor: 4.0,
+            }],
         }),
         ControlRequest::GetFrames { times, .. } => ControlResponse::Frames {
             frames: times
@@ -95,6 +140,37 @@ fn respond(req: ControlRequest) -> ControlResponse {
                 })
                 .collect(),
         },
+        ControlRequest::AddZoom { .. }
+        | ControlRequest::UpdateZoom { .. }
+        | ControlRequest::SetZoomFocus { .. }
+        | ControlRequest::RemoveZoom { .. } => ControlResponse::Zooms {
+            zooms: mock_zooms(),
+        },
+        ControlRequest::AddCut { .. }
+        | ControlRequest::UpdateCut { .. }
+        | ControlRequest::RemoveCut { .. } => ControlResponse::Cuts {
+            cuts: vec![CutSpan {
+                start: 6.5,
+                end: 7.5,
+            }],
+        },
+        ControlRequest::AutoSpeed { factor } => ControlResponse::Speeds {
+            speeds: vec![SpeedSpan {
+                start: 2.0,
+                end: 3.5,
+                factor,
+            }],
+        },
+        ControlRequest::ExportGif { .. } | ControlRequest::ExportMp4 { .. } => {
+            ControlResponse::Job { id: 1 }
+        }
+        ControlRequest::ExportStatus { id: _ } => ControlResponse::Export(ExportState {
+            done: 180,
+            total: 180,
+            finished: true,
+            error: None,
+            path: "C:/tmp/out.gif".into(),
+        }),
         ControlRequest::EstimateGif { .. } => ControlResponse::Size { bytes: 1_234_567 },
     }
 }

--- a/crates/vuoom-control/examples/mock_server.rs
+++ b/crates/vuoom-control/examples/mock_server.rs
@@ -65,12 +65,16 @@ fn mock_zooms() -> Vec<ZoomSpan> {
             end: 2.0,
             amount: 1.8,
             focus: None,
+            mode: "auto".into(),
+            rect: None,
         },
         ZoomSpan {
             start: 4.0,
             end: 6.0,
             amount: 1.8,
             focus: Some((0.3, 0.6)),
+            mode: "manual".into(),
+            rect: None,
         },
     ]
 }
@@ -128,6 +132,7 @@ fn respond(req: ControlRequest) -> ControlResponse {
                 end: 3.5,
                 factor: 4.0,
             }],
+            camera: vec![(0.0, 0.5, 0.5, 1.0), (0.25, 0.42, 0.55, 1.8)],
         }),
         ControlRequest::GetFrames { times, .. } => ControlResponse::Frames {
             frames: times

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -282,10 +282,17 @@ pub enum ControlRequest {
         index: usize,
     },
     /// Detect idle stretches and mark them to play at `factor`× (replaces existing speed
-    /// regions); answered with the new list.
+    /// regions); answered with the new list. Idle gaps shorter than `min_gap` produce no
+    /// speed region; `lead`/`tail` seconds around actions stay at normal (1×) speed.
     AutoSpeed {
         /// Speed-up factor (clamped to `[1.5, 16.0]`).
         factor: f64,
+        /// Minimum idle gap to skim, seconds (clamped `0.5..=30.0`, default 2.5).
+        min_gap: Option<f64>,
+        /// Normal-speed lead-in after the last action, seconds (clamped `0.0..=5.0`, default 0.6).
+        lead: Option<f64>,
+        /// Normal-speed tail before the next action, seconds (clamped `0.0..=5.0`, default 0.4).
+        tail: Option<f64>,
     },
     /// Remove all speed regions (play everything at 1×).
     ClearSpeed,
@@ -332,6 +339,33 @@ pub enum ControlRequest {
         width: Option<u32>,
         /// Quality 1–100.
         quality: u8,
+    },
+    /// Composite a cheap low-res animated GIF over `[start, end]` (**output-timeline**
+    /// seconds) so the agent can critique motion/pacing/easing *before* a full export.
+    /// Answered synchronously with [`ControlResponse::Preview`] — it is bounded (≤120
+    /// low-res frames), so it never needs the async export-job machinery.
+    PreviewClip {
+        /// Output-timeline start (seconds); `None` = clip start (0).
+        start: Option<f64>,
+        /// Output-timeline end (seconds); `None` = end of the output clip.
+        end: Option<f64>,
+        /// Preview frame rate (clamped `1.0..=10.0`, default 5).
+        fps: Option<f64>,
+        /// Downscale width in px (clamped `160..=640`, default 480).
+        width: Option<u32>,
+    },
+    /// Enumerate visible top-level windows (topmost first) with their physical-pixel
+    /// bounds; answered with [`ControlResponse::Windows`].
+    ListWindows,
+    /// Snap the capture region to a window's *current* bounds (best case-insensitive title
+    /// match), optionally expanded by `padding` px, clamped to the virtual screen, applied
+    /// through the normal `set_region` path. Answered with the resolved
+    /// [`ControlResponse::Region`]. Does **not** hide windows drawn above the target.
+    SetRegionToWindow {
+        /// Case-insensitive substring of the target window title (best/topmost match wins).
+        title: String,
+        /// Extra padding in px around the window (clamped `0..=200`, default 0).
+        padding: Option<i32>,
     },
 }
 
@@ -470,6 +504,49 @@ pub struct ExportState {
     pub path: String,
 }
 
+/// A low-res animated-GIF preview of the output clip, for critiquing motion before export.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PreviewInfo {
+    /// The animated GIF encoded as base64 (no data-URL prefix).
+    pub gif_base64: String,
+    /// Number of frames in the preview.
+    pub frame_count: usize,
+    /// Preview width in pixels.
+    pub width: u32,
+    /// Preview height in pixels.
+    pub height: u32,
+    /// Output-timeline duration (seconds) the preview spans.
+    pub duration: f64,
+}
+
+/// A top-level window and its physical-pixel screen rectangle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowRect {
+    /// The window title.
+    pub title: String,
+    /// Left edge (physical px; may be negative on a multi-monitor desktop).
+    pub x: i32,
+    /// Top edge (physical px).
+    pub y: i32,
+    /// Width (physical px).
+    pub w: u32,
+    /// Height (physical px).
+    pub h: u32,
+}
+
+/// A resolved capture region (physical px) — the reply to [`ControlRequest::SetRegionToWindow`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegionRect {
+    /// Left edge (physical px).
+    pub x: u32,
+    /// Top edge (physical px).
+    pub y: u32,
+    /// Width (physical px).
+    pub w: u32,
+    /// Height (physical px).
+    pub h: u32,
+}
+
 /// The server's reply to a [`ControlRequest`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
@@ -523,6 +600,15 @@ pub enum ControlResponse {
         /// Estimated export size in bytes.
         bytes: u64,
     },
+    /// Reply to [`ControlRequest::PreviewClip`] — the low-res animated GIF + metadata.
+    Preview(PreviewInfo),
+    /// Reply to [`ControlRequest::ListWindows`] — the visible top-level windows.
+    Windows {
+        /// The enumerated windows (topmost first).
+        windows: Vec<WindowRect>,
+    },
+    /// Reply to [`ControlRequest::SetRegionToWindow`] — the resolved capture region.
+    Region(RegionRect),
 }
 
 impl ControlResponse {
@@ -786,7 +872,12 @@ mod tests {
                 end: 2.5,
             },
             ControlRequest::RemoveCut { index: 0 },
-            ControlRequest::AutoSpeed { factor: 4.0 },
+            ControlRequest::AutoSpeed {
+                factor: 4.0,
+                min_gap: Some(3.0),
+                lead: None,
+                tail: Some(0.5),
+            },
             ControlRequest::ClearSpeed,
             ControlRequest::SetTrim {
                 start: 0.5,
@@ -809,6 +900,17 @@ mod tests {
                 fps: 20,
                 width: None,
                 quality: 80,
+            },
+            ControlRequest::PreviewClip {
+                start: Some(0.5),
+                end: Some(3.0),
+                fps: Some(5.0),
+                width: Some(480),
+            },
+            ControlRequest::ListWindows,
+            ControlRequest::SetRegionToWindow {
+                title: "Notepad".into(),
+                padding: Some(12),
             },
         ];
         for req in cases {
@@ -918,6 +1020,46 @@ mod tests {
         );
     }
 
+    /// The new window/preview requests parse with their optional fields omitted.
+    #[test]
+    fn window_and_preview_defaults_when_missing() {
+        let preview: ControlRequest =
+            serde_json::from_str(r#"{"op":"preview_clip"}"#).expect("parse");
+        assert_eq!(
+            preview,
+            ControlRequest::PreviewClip {
+                start: None,
+                end: None,
+                fps: None,
+                width: None,
+            }
+        );
+        let region: ControlRequest =
+            serde_json::from_str(r#"{"op":"set_region_to_window","title":"Firefox"}"#)
+                .expect("parse");
+        assert_eq!(
+            region,
+            ControlRequest::SetRegionToWindow {
+                title: "Firefox".into(),
+                padding: None,
+            }
+        );
+        let list: ControlRequest = serde_json::from_str(r#"{"op":"list_windows"}"#).expect("parse");
+        assert_eq!(list, ControlRequest::ListWindows);
+        // Pre-existing callers pass only `factor`; the new pacing knobs default to None.
+        let speed: ControlRequest =
+            serde_json::from_str(r#"{"op":"auto_speed","factor":4.0}"#).expect("parse");
+        assert_eq!(
+            speed,
+            ControlRequest::AutoSpeed {
+                factor: 4.0,
+                min_gap: None,
+                lead: None,
+                tail: None,
+            }
+        );
+    }
+
     /// Every response variant must survive a JSON round-trip unchanged.
     #[test]
     fn responses_round_trip() {
@@ -1002,6 +1144,28 @@ mod tests {
                 path: "C:/tmp/out.gif".into(),
             }),
             ControlResponse::Size { bytes: 1_234_567 },
+            ControlResponse::Preview(PreviewInfo {
+                gif_base64: "AAAA".into(),
+                frame_count: 30,
+                width: 480,
+                height: 270,
+                duration: 6.0,
+            }),
+            ControlResponse::Windows {
+                windows: vec![WindowRect {
+                    title: "Notepad".into(),
+                    x: 10,
+                    y: 20,
+                    w: 800,
+                    h: 600,
+                }],
+            },
+            ControlResponse::Region(RegionRect {
+                x: 0,
+                y: 0,
+                w: 640,
+                h: 480,
+            }),
         ];
         for resp in cases {
             let line = serde_json::to_string(&resp).expect("serialize");

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -14,6 +14,7 @@
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::TcpStream;
+use std::path::{Path, PathBuf};
 
 /// A mouse button for an injected click.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -244,6 +245,55 @@ impl ControlResponse {
     }
 }
 
+/// On-disk record of the port the control server bound to, for sidecar discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct PortFile {
+    port: u16,
+}
+
+/// The well-known file the control server writes its chosen port to, so the standalone
+/// MCP sidecar (a separate process) can find it: `%TEMP%/vuoom-control.json`.
+#[must_use]
+pub fn port_file_path() -> PathBuf {
+    std::env::temp_dir().join("vuoom-control.json")
+}
+
+/// Write `port` to `path` as `{"port": N}`.
+///
+/// # Errors
+/// Returns any serialization or I/O error.
+pub fn write_port_file_at(path: &Path, port: u16) -> io::Result<()> {
+    let bytes = serde_json::to_vec(&PortFile { port })?;
+    std::fs::write(path, bytes)
+}
+
+/// Write the control port to the well-known [`port_file_path`].
+///
+/// # Errors
+/// Returns any serialization or I/O error.
+pub fn write_port_file(port: u16) -> io::Result<()> {
+    write_port_file_at(&port_file_path(), port)
+}
+
+/// Read a control port from `path`, returning `None` if it is missing or malformed.
+#[must_use]
+pub fn read_port_at(path: &Path) -> Option<u16> {
+    let data = std::fs::read(path).ok()?;
+    let pf: PortFile = serde_json::from_slice(&data).ok()?;
+    Some(pf.port)
+}
+
+/// Discover the control port: the `VUOOM_CONTROL_PORT` env var wins, else the port file.
+#[must_use]
+pub fn discover_port() -> Option<u16> {
+    if let Ok(p) = std::env::var("VUOOM_CONTROL_PORT") {
+        if let Ok(port) = p.trim().parse::<u16>() {
+            return Some(port);
+        }
+    }
+    read_port_at(&port_file_path())
+}
+
 /// Write `msg` as a single newline-terminated JSON line and flush.
 ///
 /// # Errors
@@ -406,6 +456,20 @@ mod tests {
             let back: ControlResponse = serde_json::from_str(&line).expect("deserialize");
             assert_eq!(resp, back);
         }
+    }
+
+    /// The port file round-trips, and a missing/garbage file reads back as `None`.
+    #[test]
+    fn port_file_round_trips() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("vuoom-control-test-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read_port_at(&path), None);
+        write_port_file_at(&path, 54321).expect("write");
+        assert_eq!(read_port_at(&path), Some(54321));
+        std::fs::write(&path, b"not json").expect("write garbage");
+        assert_eq!(read_port_at(&path), None);
+        let _ = std::fs::remove_file(&path);
     }
 
     /// `write_message` emits exactly one trailing newline and a parseable body.

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -59,6 +59,12 @@ pub enum ControlRequest {
         /// Multiplier in `[1.0, 4.0]` (clamped server-side).
         amount: f64,
     },
+    /// Enable/disable click-driven auto-zoom for the next recording. The agent drives via
+    /// clicks, so this is on for agent recordings (Vuoom's interactive default is manual).
+    SetAutoZoomOnClick {
+        /// `true` = every click seeds a cinematic zoom; `false` = manual hotkey only.
+        on: bool,
+    },
     /// Begin capturing the screen + global input.
     StartRecording,
     /// Stop capturing and build the editable project; answered with [`ControlResponse::Recording`].
@@ -365,6 +371,7 @@ mod tests {
                 h: None,
             },
             ControlRequest::SetZoomAmount { amount: 2.0 },
+            ControlRequest::SetAutoZoomOnClick { on: true },
             ControlRequest::StartRecording,
             ControlRequest::StopRecording,
             ControlRequest::SetPaused { paused: true },

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -1,0 +1,422 @@
+//! Control protocol for Vuoom's AI Demo Director.
+//!
+//! Vuoom runs a small localhost control server (in `src-tauri`) that an AI agent drives
+//! through the standalone [`vuoom-mcp`](../vuoom_mcp/index.html) sidecar. This crate is the
+//! contract between them: the request/response types plus a tiny blocking TCP [`Client`].
+//!
+//! The wire format is **newline-delimited JSON**: each request is one line, each response is
+//! one line. That keeps the server trivial (read a line → dispatch → write a line) and the
+//! whole crate dependency-light (just serde), so it compiles fast and is fully
+//! unit-testable without a GPU/display. See `docs/13-AI-Demo-Director-Research.md`.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use std::io::{self, BufRead, BufReader, Write};
+use std::net::TcpStream;
+
+/// A mouse button for an injected click.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Button {
+    /// The primary (left) button.
+    #[default]
+    Left,
+    /// The secondary (right) button.
+    Right,
+    /// The middle (wheel) button.
+    Middle,
+}
+
+/// A command sent from the agent (via the MCP sidecar) to Vuoom's control server.
+///
+/// All screen coordinates are **virtual-desktop physical pixels** — the same space the
+/// capture and auto-zoom planner work in — so an injected click lands exactly where the
+/// agent saw it and the zoom centres on the right spot. Use [`ControlRequest::ScreenGeometry`]
+/// to learn the desktop bounds first.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ControlRequest {
+    /// Liveness check — the server answers [`ControlResponse::Ok`].
+    Ping,
+    /// Ask for the virtual-desktop bounds (so the agent can reason in screen pixels).
+    ScreenGeometry,
+    /// Set the capture region (physical px) for the next recording. Omit all fields (or pass
+    /// a zero-area rect) to capture the full screen.
+    SetRegion {
+        /// Left edge (physical px); `None` = full screen.
+        x: Option<u32>,
+        /// Top edge (physical px).
+        y: Option<u32>,
+        /// Width (physical px).
+        w: Option<u32>,
+        /// Height (physical px).
+        h: Option<u32>,
+    },
+    /// Set the zoom multiplier (1.0 = no zoom) applied to the next recording.
+    SetZoomAmount {
+        /// Multiplier in `[1.0, 4.0]` (clamped server-side).
+        amount: f64,
+    },
+    /// Begin capturing the screen + global input.
+    StartRecording,
+    /// Stop capturing and build the editable project; answered with [`ControlResponse::Recording`].
+    StopRecording,
+    /// Pause or resume the running recording (a paused span becomes a cut).
+    SetPaused {
+        /// `true` to pause, `false` to resume.
+        paused: bool,
+    },
+    /// Move the cursor to `(x, y)` without clicking.
+    MoveCursor {
+        /// Target x (physical px).
+        x: i32,
+        /// Target y (physical px).
+        y: i32,
+    },
+    /// Click at `(x, y)`. These synthetic clicks flow through Vuoom's input hook exactly like
+    /// real ones, so they drive both the target app and the cinematic auto-zoom.
+    Click {
+        /// Click x (physical px).
+        x: i32,
+        /// Click y (physical px).
+        y: i32,
+        /// Which button (defaults to left).
+        #[serde(default)]
+        button: Button,
+        /// `true` for a double-click.
+        #[serde(default)]
+        double: bool,
+    },
+    /// Type a string of Unicode text into the focused control.
+    TypeText {
+        /// The text to type.
+        text: String,
+    },
+    /// Press a key chord, e.g. `["ctrl", "c"]` or `["enter"]`. Modifiers are held while the
+    /// final key is tapped, then released in reverse order.
+    KeyChord {
+        /// Key names (modifiers first); see [`crate::key`] for accepted names.
+        keys: Vec<String>,
+    },
+    /// Scroll the wheel at `(x, y)`; positive `delta` scrolls up.
+    Scroll {
+        /// Pointer x (physical px).
+        x: i32,
+        /// Pointer y (physical px).
+        y: i32,
+        /// Wheel delta in notches (positive = up).
+        delta: i32,
+    },
+    /// Composite and publish the preview frame at time `t` (seconds).
+    Seek {
+        /// Time from the clip start, in seconds.
+        t: f64,
+    },
+    /// Ask for a summary of the current clip (duration, zoom/cut counts).
+    ClipState,
+    /// Composite the given times and return them as PNGs so the agent can *see* the result
+    /// and critique it. Sample sparsely (e.g. around each zoom) to keep cost down.
+    GetFrames {
+        /// Times (seconds) to sample.
+        times: Vec<f64>,
+        /// Optional max width (px) to downscale each returned frame.
+        width: Option<u32>,
+    },
+    /// Export the edited clip to an animated GIF.
+    ExportGif {
+        /// Absolute output path.
+        path: String,
+        /// Output frame rate.
+        fps: u32,
+        /// Optional max width (px).
+        width: Option<u32>,
+        /// Quality 1–100.
+        quality: u8,
+    },
+    /// Export the edited clip to an H.264 MP4.
+    ExportMp4 {
+        /// Absolute output path.
+        path: String,
+        /// Output frame rate.
+        fps: u32,
+        /// Optional max width (px).
+        width: Option<u32>,
+        /// Quality 1–100.
+        quality: u8,
+    },
+    /// Estimate the GIF export size (bytes) for the given settings.
+    EstimateGif {
+        /// Output frame rate.
+        fps: u32,
+        /// Optional max width (px).
+        width: Option<u32>,
+        /// Quality 1–100.
+        quality: u8,
+    },
+}
+
+/// The virtual-desktop bounds in physical pixels (origin can be negative with multi-monitor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScreenGeometry {
+    /// Left edge of the virtual desktop.
+    pub x: i32,
+    /// Top edge of the virtual desktop.
+    pub y: i32,
+    /// Total width across all monitors.
+    pub width: i32,
+    /// Total height across all monitors.
+    pub height: i32,
+}
+
+/// Summary of a finished recording.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RecordingSummary {
+    /// Clip length in seconds.
+    pub duration: f64,
+    /// Number of captured frames.
+    pub frames: usize,
+    /// Number of auto-planned zoom segments.
+    pub zooms: usize,
+}
+
+/// A compact view of the current clip's editable state.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ClipInfo {
+    /// Clip length in seconds.
+    pub duration: f64,
+    /// Number of zoom segments.
+    pub zooms: usize,
+    /// Number of cuts.
+    pub cuts: usize,
+    /// Number of speed regions.
+    pub speed_regions: usize,
+}
+
+/// A single composited frame, returned for the agent to inspect.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrameShot {
+    /// The time (seconds) this frame was sampled at.
+    pub t: f64,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// The frame encoded as a base64 PNG (no data-URL prefix).
+    pub png_base64: String,
+}
+
+/// The server's reply to a [`ControlRequest`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ControlResponse {
+    /// The command succeeded with no payload.
+    Ok,
+    /// The command failed; `message` explains why.
+    Error {
+        /// Human-readable failure reason.
+        message: String,
+    },
+    /// Reply to [`ControlRequest::ScreenGeometry`].
+    Geometry(ScreenGeometry),
+    /// Reply to [`ControlRequest::StopRecording`].
+    Recording(RecordingSummary),
+    /// Reply to [`ControlRequest::ClipState`].
+    Clip(ClipInfo),
+    /// Reply to [`ControlRequest::GetFrames`].
+    Frames {
+        /// The sampled frames, in request order.
+        frames: Vec<FrameShot>,
+    },
+    /// Reply to [`ControlRequest::EstimateGif`] — estimated size in bytes.
+    Size {
+        /// Estimated export size in bytes.
+        bytes: u64,
+    },
+}
+
+impl ControlResponse {
+    /// Build an [`ControlResponse::Error`] from anything string-like.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::Error {
+            message: message.into(),
+        }
+    }
+}
+
+/// Write `msg` as a single newline-terminated JSON line and flush.
+///
+/// # Errors
+/// Returns any serialization or I/O error.
+pub fn write_message<W: Write, T: Serialize>(w: &mut W, msg: &T) -> io::Result<()> {
+    let line = serde_json::to_string(msg)?;
+    w.write_all(line.as_bytes())?;
+    w.write_all(b"\n")?;
+    w.flush()
+}
+
+/// A blocking client for Vuoom's control server, used by the MCP sidecar.
+pub struct Client {
+    stream: TcpStream,
+    reader: BufReader<TcpStream>,
+}
+
+impl Client {
+    /// Connect to the control server on `127.0.0.1:port`.
+    ///
+    /// # Errors
+    /// Returns an [`io::Error`] if the connection cannot be established.
+    pub fn connect(port: u16) -> io::Result<Self> {
+        let stream = TcpStream::connect(("127.0.0.1", port))?;
+        let reader = BufReader::new(stream.try_clone()?);
+        Ok(Self { stream, reader })
+    }
+
+    /// Send one request and read exactly one response.
+    ///
+    /// # Errors
+    /// Returns a message on serialization, I/O, or connection-closed errors. A
+    /// [`ControlResponse::Error`] from the server is returned as `Ok(Error { .. })`, not `Err`
+    /// — only transport failures are `Err`.
+    pub fn call(&mut self, req: &ControlRequest) -> Result<ControlResponse, String> {
+        write_message(&mut self.stream, req).map_err(|e| e.to_string())?;
+        let mut line = String::new();
+        let n = self
+            .reader
+            .read_line(&mut line)
+            .map_err(|e| e.to_string())?;
+        if n == 0 {
+            return Err("control server closed the connection".into());
+        }
+        serde_json::from_str(&line).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every request variant must survive a JSON round-trip unchanged.
+    #[test]
+    fn requests_round_trip() {
+        let cases = vec![
+            ControlRequest::Ping,
+            ControlRequest::ScreenGeometry,
+            ControlRequest::SetRegion {
+                x: Some(10),
+                y: Some(20),
+                w: Some(640),
+                h: Some(480),
+            },
+            ControlRequest::SetRegion {
+                x: None,
+                y: None,
+                w: None,
+                h: None,
+            },
+            ControlRequest::SetZoomAmount { amount: 2.0 },
+            ControlRequest::StartRecording,
+            ControlRequest::StopRecording,
+            ControlRequest::SetPaused { paused: true },
+            ControlRequest::MoveCursor { x: -5, y: 100 },
+            ControlRequest::Click {
+                x: 1,
+                y: 2,
+                button: Button::Right,
+                double: true,
+            },
+            ControlRequest::TypeText {
+                text: "hello world".into(),
+            },
+            ControlRequest::KeyChord {
+                keys: vec!["ctrl".into(), "c".into()],
+            },
+            ControlRequest::Scroll {
+                x: 3,
+                y: 4,
+                delta: -2,
+            },
+            ControlRequest::Seek { t: 1.5 },
+            ControlRequest::ClipState,
+            ControlRequest::GetFrames {
+                times: vec![0.0, 1.0, 2.5],
+                width: Some(800),
+            },
+            ControlRequest::ExportGif {
+                path: "C:/tmp/out.gif".into(),
+                fps: 20,
+                width: Some(900),
+                quality: 80,
+            },
+            ControlRequest::ExportMp4 {
+                path: "C:/tmp/out.mp4".into(),
+                fps: 30,
+                width: None,
+                quality: 75,
+            },
+            ControlRequest::EstimateGif {
+                fps: 20,
+                width: None,
+                quality: 80,
+            },
+        ];
+        for req in cases {
+            let line = serde_json::to_string(&req).expect("serialize");
+            assert!(!line.contains('\n'), "requests must be single-line");
+            let back: ControlRequest = serde_json::from_str(&line).expect("deserialize");
+            assert_eq!(req, back);
+        }
+    }
+
+    /// Every response variant must survive a JSON round-trip unchanged.
+    #[test]
+    fn responses_round_trip() {
+        let cases = vec![
+            ControlResponse::Ok,
+            ControlResponse::error("boom"),
+            ControlResponse::Geometry(ScreenGeometry {
+                x: -1920,
+                y: 0,
+                width: 3840,
+                height: 1080,
+            }),
+            ControlResponse::Recording(RecordingSummary {
+                duration: 12.5,
+                frames: 750,
+                zooms: 3,
+            }),
+            ControlResponse::Clip(ClipInfo {
+                duration: 12.5,
+                zooms: 3,
+                cuts: 1,
+                speed_regions: 2,
+            }),
+            ControlResponse::Frames {
+                frames: vec![FrameShot {
+                    t: 1.0,
+                    width: 4,
+                    height: 2,
+                    png_base64: "AAAA".into(),
+                }],
+            },
+            ControlResponse::Size { bytes: 1_234_567 },
+        ];
+        for resp in cases {
+            let line = serde_json::to_string(&resp).expect("serialize");
+            let back: ControlResponse = serde_json::from_str(&line).expect("deserialize");
+            assert_eq!(resp, back);
+        }
+    }
+
+    /// `write_message` emits exactly one trailing newline and a parseable body.
+    #[test]
+    fn write_message_is_one_line() {
+        let mut buf = Vec::new();
+        write_message(&mut buf, &ControlRequest::Ping).expect("write");
+        assert_eq!(buf.last(), Some(&b'\n'));
+        let text = String::from_utf8(buf).expect("utf8");
+        assert_eq!(text.matches('\n').count(), 1);
+        let req: ControlRequest = serde_json::from_str(text.trim_end()).expect("parse");
+        assert_eq!(req, ControlRequest::Ping);
+    }
+}

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -8,13 +8,25 @@
 //! one line. That keeps the server trivial (read a line → dispatch → write a line) and the
 //! whole crate dependency-light (just serde), so it compiles fast and is fully
 //! unit-testable without a GPU/display. See `docs/13-AI-Demo-Director-Research.md`.
+//!
+//! **Authentication.** Loopback is not a trust boundary — any local process could otherwise
+//! drive input injection. The server generates a random [`generate_token`] at startup,
+//! publishes it in the discovery file next to the port, and requires it as the first line
+//! of every connection before any request is served.
 
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, BufReader, Write};
-use std::net::TcpStream;
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// How long the client waits for a connection to be accepted.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long the client waits for a single reply. Generous because `get_frames` composites
+/// on the GPU; exports are asynchronous jobs precisely so they never hit this.
+pub const READ_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// A mouse button for an injected click.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -34,7 +46,9 @@ pub enum Button {
 /// All screen coordinates are **virtual-desktop physical pixels** — the same space the
 /// capture and auto-zoom planner work in — so an injected click lands exactly where the
 /// agent saw it and the zoom centres on the right spot. Use [`ControlRequest::ScreenGeometry`]
-/// to learn the desktop bounds first.
+/// to learn the desktop bounds first. Clip/edit times are seconds; unless stated otherwise
+/// they are **output-timeline** for sampling and **source-timeline** for edit ops (matching
+/// the editor UI).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum ControlRequest {
@@ -42,6 +56,12 @@ pub enum ControlRequest {
     Ping,
     /// Ask for the virtual-desktop bounds (so the agent can reason in screen pixels).
     ScreenGeometry,
+    /// Capture the screen **right now** (independent of any recording) so the agent can see
+    /// the current state and locate what to click. Answered with [`ControlResponse::Shot`].
+    Screenshot {
+        /// Optional max width (px) to downscale the returned PNG.
+        width: Option<u32>,
+    },
     /// Set the capture region (physical px) for the next recording. Omit all fields (or pass
     /// a zero-area rect) to capture the full screen.
     SetRegion {
@@ -59,30 +79,47 @@ pub enum ControlRequest {
         /// Multiplier in `[1.0, 4.0]` (clamped server-side).
         amount: f64,
     },
-    /// Enable/disable click-driven auto-zoom for the next recording. The agent drives via
-    /// clicks, so this is on for agent recordings (Vuoom's interactive default is manual).
-    SetAutoZoomOnClick {
-        /// `true` = every click seeds a cinematic zoom; `false` = manual hotkey only.
-        on: bool,
+    /// Tune the auto-zoom *feel* for the next recording. `None` fields keep the defaults.
+    SetZoomStyle {
+        /// Seconds of inactivity before the camera zooms back out.
+        hold: Option<f64>,
+        /// Seconds of anticipation before a click that the zoom-in begins.
+        pre_roll: Option<f64>,
+        /// Half-life (s) of the zoom spring — smaller = snappier zoom.
+        hl_zoom: Option<f64>,
+        /// Half-life (s) of the pan spring — smaller = snappier follow.
+        hl_pan: Option<f64>,
     },
-    /// Begin capturing the screen + global input.
-    StartRecording,
+    /// Begin capturing the screen + global input. `auto_zoom_on_click` defaults to `true`
+    /// for agent recordings (the agent drives via clicks); the flag applies to **this**
+    /// recording only and never leaks into interactive use.
+    StartRecording {
+        /// `true` (default) = every click seeds a cinematic zoom; `false` = manual only.
+        auto_zoom_on_click: Option<bool>,
+    },
     /// Stop capturing and build the editable project; answered with [`ControlResponse::Recording`].
     StopRecording,
+    /// Stop capturing and **discard** the take (no project is built).
+    CancelRecording,
     /// Pause or resume the running recording (a paused span becomes a cut).
     SetPaused {
         /// `true` to pause, `false` to resume.
         paused: bool,
     },
-    /// Move the cursor to `(x, y)` without clicking.
+    /// Ask what the engine is doing; answered with [`ControlResponse::Status`].
+    Status,
+    /// Glide the cursor to `(x, y)` without clicking (minimum-jerk path).
     MoveCursor {
         /// Target x (physical px).
         x: i32,
         /// Target y (physical px).
         y: i32,
+        /// Glide time in ms; `None` = distance-scaled, `0` = instant warp.
+        duration_ms: Option<u32>,
     },
-    /// Click at `(x, y)`. These synthetic clicks flow through Vuoom's input hook exactly like
-    /// real ones, so they drive both the target app and the cinematic auto-zoom.
+    /// Glide to `(x, y)`, settle, and click. These synthetic clicks flow through Vuoom's
+    /// input hook exactly like real ones, so they drive both the target app and the
+    /// cinematic auto-zoom.
     Click {
         /// Click x (physical px).
         x: i32,
@@ -94,19 +131,39 @@ pub enum ControlRequest {
         /// `true` for a double-click.
         #[serde(default)]
         double: bool,
+        /// Glide time in ms; `None` = distance-scaled, `0` = instant warp.
+        glide_ms: Option<u32>,
     },
-    /// Type a string of Unicode text into the focused control.
+    /// Press-drag from `(x1, y1)` to `(x2, y2)` — sliders, drag-and-drop, text selection.
+    Drag {
+        /// Drag start x (physical px).
+        x1: i32,
+        /// Drag start y (physical px).
+        y1: i32,
+        /// Drag end x (physical px).
+        x2: i32,
+        /// Drag end y (physical px).
+        y2: i32,
+        /// Which button to hold (defaults to left).
+        #[serde(default)]
+        button: Button,
+        /// Duration of the dragging portion in ms; `None` = distance-scaled.
+        duration_ms: Option<u32>,
+    },
+    /// Type a string of Unicode text into the focused control at a human cadence.
     TypeText {
-        /// The text to type.
+        /// The text to type. `\n`/`\t` press real Enter/Tab.
         text: String,
+        /// Characters per second; `None` = ~15 with natural jitter.
+        cps: Option<f64>,
     },
     /// Press a key chord, e.g. `["ctrl", "c"]` or `["enter"]`. Modifiers are held while the
     /// final key is tapped, then released in reverse order.
     KeyChord {
-        /// Key names (modifiers first); see [`crate::key`] for accepted names.
+        /// Key names (modifiers first); see the injection key table for accepted names.
         keys: Vec<String>,
     },
-    /// Scroll the wheel at `(x, y)`; positive `delta` scrolls up.
+    /// Scroll the wheel at `(x, y)`; positive `delta` scrolls up, one notch per step.
     Scroll {
         /// Pointer x (physical px).
         x: i32,
@@ -114,23 +171,93 @@ pub enum ControlRequest {
         y: i32,
         /// Wheel delta in notches (positive = up).
         delta: i32,
+        /// Gap between notches in ms; `None` = 40, `0` = all at once.
+        step_ms: Option<u32>,
     },
-    /// Composite and publish the preview frame at time `t` (seconds).
+    /// Composite and publish the preview frame at time `t` (seconds, output timeline).
     Seek {
         /// Time from the clip start, in seconds.
         t: f64,
     },
-    /// Ask for a summary of the current clip (duration, zoom/cut counts).
+    /// Ask for the full editable state of the clip (durations, zoom/cut/speed spans).
     ClipState,
-    /// Composite the given times and return them as PNGs so the agent can *see* the result
-    /// and critique it. Sample sparsely (e.g. around each zoom) to keep cost down.
+    /// Composite the given **output-timeline** times and return them as PNGs so the agent
+    /// can *see* exactly what the export will produce, and critique it. Sample sparsely
+    /// (e.g. around each zoom span from [`ControlRequest::ClipState`]) to keep cost down.
     GetFrames {
-        /// Times (seconds) to sample.
+        /// Times (seconds, output timeline) to sample.
         times: Vec<f64>,
         /// Optional max width (px) to downscale each returned frame.
         width: Option<u32>,
     },
-    /// Export the edited clip to an animated GIF.
+    /// Insert a zoom segment starting at source time `t`; answered with the updated list.
+    AddZoom {
+        /// Source-timeline start (seconds); the segment gets a default length.
+        t: f64,
+    },
+    /// Retime / re-level the zoom at `index`; answered with the updated list.
+    UpdateZoom {
+        /// Index into the sorted zoom list (see [`ControlRequest::ClipState`]).
+        index: usize,
+        /// New start (source seconds).
+        start: f64,
+        /// New end (source seconds).
+        end: f64,
+        /// New zoom multiplier (clamped to `[1.1, 4.0]`).
+        amount: f64,
+    },
+    /// Re-centre the zoom at `index`: fixed normalized focus, or follow the cursor again.
+    SetZoomFocus {
+        /// Index into the sorted zoom list.
+        index: usize,
+        /// Normalized focus x in `[0, 1]`; omit both to follow the cursor.
+        x: Option<f64>,
+        /// Normalized focus y in `[0, 1]`.
+        y: Option<f64>,
+    },
+    /// Delete the zoom at `index`; answered with the updated list.
+    RemoveZoom {
+        /// Index into the sorted zoom list.
+        index: usize,
+    },
+    /// Remove `[start, end]` (source seconds) from the output; answered with updated cuts.
+    AddCut {
+        /// Cut start (source seconds).
+        start: f64,
+        /// Cut end (source seconds).
+        end: f64,
+    },
+    /// Retime the cut at `index`; answered with the updated list.
+    UpdateCut {
+        /// Index into the sorted cut list.
+        index: usize,
+        /// New start (source seconds).
+        start: f64,
+        /// New end (source seconds).
+        end: f64,
+    },
+    /// Restore the cut at `index`; answered with the updated list.
+    RemoveCut {
+        /// Index into the sorted cut list.
+        index: usize,
+    },
+    /// Detect idle stretches and mark them to play at `factor`× (replaces existing speed
+    /// regions); answered with the new list.
+    AutoSpeed {
+        /// Speed-up factor (clamped to `[1.5, 16.0]`).
+        factor: f64,
+    },
+    /// Remove all speed regions (play everything at 1×).
+    ClearSpeed,
+    /// Trim the clip to `[start, end]` (source seconds); the full range clears the trim.
+    SetTrim {
+        /// Trim start (source seconds).
+        start: f64,
+        /// Trim end (source seconds).
+        end: f64,
+    },
+    /// Start exporting the edited clip to an animated GIF. Answered immediately with
+    /// [`ControlResponse::Job`]; poll with [`ControlRequest::ExportStatus`].
     ExportGif {
         /// Absolute output path.
         path: String,
@@ -141,7 +268,7 @@ pub enum ControlRequest {
         /// Quality 1–100.
         quality: u8,
     },
-    /// Export the edited clip to an H.264 MP4.
+    /// Start exporting the edited clip to an H.264 MP4 (job-based, like `ExportGif`).
     ExportMp4 {
         /// Absolute output path.
         path: String,
@@ -151,6 +278,11 @@ pub enum ControlRequest {
         width: Option<u32>,
         /// Quality 1–100.
         quality: u8,
+    },
+    /// Ask how an export job is doing; answered with [`ControlResponse::Export`].
+    ExportStatus {
+        /// The id returned by `ExportGif`/`ExportMp4`.
+        id: u64,
     },
     /// Estimate the GIF export size (bytes) for the given settings.
     EstimateGif {
@@ -179,7 +311,7 @@ pub struct ScreenGeometry {
 /// Summary of a finished recording.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RecordingSummary {
-    /// Clip length in seconds.
+    /// Clip length in seconds (source timeline).
     pub duration: f64,
     /// Number of captured frames.
     pub frames: usize,
@@ -187,23 +319,83 @@ pub struct RecordingSummary {
     pub zooms: usize,
 }
 
-/// A compact view of the current clip's editable state.
+/// One zoom segment on the source timeline.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ZoomSpan {
+    /// Segment start (source seconds).
+    pub start: f64,
+    /// Segment end (source seconds).
+    pub end: f64,
+    /// Zoom multiplier while active.
+    pub amount: f64,
+    /// Fixed normalized focus when manually set; `None` = the camera follows the cursor.
+    pub focus: Option<(f64, f64)>,
+}
+
+/// One cut (removed span) on the source timeline.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CutSpan {
+    /// Cut start (source seconds).
+    pub start: f64,
+    /// Cut end (source seconds).
+    pub end: f64,
+}
+
+/// One speed region on the source timeline.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SpeedSpan {
+    /// Region start (source seconds).
+    pub start: f64,
+    /// Region end (source seconds).
+    pub end: f64,
+    /// Playback factor (e.g. 4.0 = 4× faster).
+    pub factor: f64,
+}
+
+/// What the engine is currently doing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordState {
+    /// No recording running, no clip loaded.
+    Idle,
+    /// Actively capturing.
+    Recording,
+    /// Capturing, but paused (the span will become a cut).
+    Paused,
+    /// A finished clip is loaded and editable/exportable.
+    ClipReady,
+}
+
+/// Reply to [`ControlRequest::Status`].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct StatusInfo {
+    /// The engine state.
+    pub state: RecordState,
+    /// Seconds since the recording started (present while recording/paused).
+    pub elapsed: Option<f64>,
+}
+
+/// The full editable state of the current clip — everything the agent needs to critique
+/// and repair a take without re-recording.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClipInfo {
-    /// Clip length in seconds.
+    /// Source-timeline length in seconds.
     pub duration: f64,
-    /// Number of zoom segments.
-    pub zooms: usize,
-    /// Number of cuts.
-    pub cuts: usize,
-    /// Number of speed regions.
-    pub speed_regions: usize,
+    /// Output-timeline length (after trim + cuts + speed) — what the export produces and
+    /// the timeline [`ControlRequest::GetFrames`]/[`ControlRequest::Seek`] sample in.
+    pub output_duration: f64,
+    /// The zoom segments, sorted by start (edit ops address them by this index).
+    pub zooms: Vec<ZoomSpan>,
+    /// The cuts, sorted by start.
+    pub cuts: Vec<CutSpan>,
+    /// The speed regions, sorted by start.
+    pub speeds: Vec<SpeedSpan>,
 }
 
 /// A single composited frame, returned for the agent to inspect.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FrameShot {
-    /// The time (seconds) this frame was sampled at.
+    /// The time (seconds, output timeline) this frame was sampled at; `0.0` for live shots.
     pub t: f64,
     /// Frame width in pixels.
     pub width: u32,
@@ -211,6 +403,21 @@ pub struct FrameShot {
     pub height: u32,
     /// The frame encoded as a base64 PNG (no data-URL prefix).
     pub png_base64: String,
+}
+
+/// Progress of an asynchronous export job.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExportState {
+    /// Frames composited so far.
+    pub done: u64,
+    /// Total frames to composite (0 until known).
+    pub total: u64,
+    /// Whether the job has finished (successfully or not).
+    pub finished: bool,
+    /// The failure reason, if the job failed.
+    pub error: Option<String>,
+    /// The output path the job writes to.
+    pub path: String,
 }
 
 /// The server's reply to a [`ControlRequest`].
@@ -230,11 +437,37 @@ pub enum ControlResponse {
     Recording(RecordingSummary),
     /// Reply to [`ControlRequest::ClipState`].
     Clip(ClipInfo),
+    /// Reply to [`ControlRequest::Status`].
+    Status(StatusInfo),
+    /// Reply to [`ControlRequest::Screenshot`].
+    Shot(FrameShot),
     /// Reply to [`ControlRequest::GetFrames`].
     Frames {
         /// The sampled frames, in request order.
         frames: Vec<FrameShot>,
     },
+    /// Reply to the zoom edit ops — the updated, sorted segment list.
+    Zooms {
+        /// All zoom segments after the edit.
+        zooms: Vec<ZoomSpan>,
+    },
+    /// Reply to the cut edit ops — the updated, sorted cut list.
+    Cuts {
+        /// All cuts after the edit.
+        cuts: Vec<CutSpan>,
+    },
+    /// Reply to [`ControlRequest::AutoSpeed`] — the new speed regions.
+    Speeds {
+        /// All speed regions after the edit.
+        speeds: Vec<SpeedSpan>,
+    },
+    /// Reply to [`ControlRequest::ExportGif`]/[`ControlRequest::ExportMp4`] — the job id.
+    Job {
+        /// Pass to [`ControlRequest::ExportStatus`] to poll progress.
+        id: u64,
+    },
+    /// Reply to [`ControlRequest::ExportStatus`].
+    Export(ExportState),
     /// Reply to [`ControlRequest::EstimateGif`] — estimated size in bytes.
     Size {
         /// Estimated export size in bytes.
@@ -251,53 +484,80 @@ impl ControlResponse {
     }
 }
 
-/// On-disk record of the port the control server bound to, for sidecar discovery.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// On-disk record of the control server endpoint, for sidecar discovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PortFile {
     port: u16,
+    #[serde(default)]
+    token: String,
 }
 
-/// The well-known file the control server writes its chosen port to, so the standalone
+/// The well-known file the control server writes its endpoint to, so the standalone
 /// MCP sidecar (a separate process) can find it: `%TEMP%/vuoom-control.json`.
 #[must_use]
 pub fn port_file_path() -> PathBuf {
     std::env::temp_dir().join("vuoom-control.json")
 }
 
-/// Write `port` to `path` as `{"port": N}`.
+/// Generate a fresh 128-bit hex auth token.
+///
+/// Uses the OS-seeded per-process randomness behind `RandomState` — no extra dependency,
+/// and unguessable by other local processes.
+#[must_use]
+pub fn generate_token() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let a = RandomState::new().build_hasher().finish();
+    let b = RandomState::new().build_hasher().finish();
+    format!("{a:016x}{b:016x}")
+}
+
+/// Write the endpoint to `path` as `{"port": N, "token": "..."}`.
 ///
 /// # Errors
 /// Returns any serialization or I/O error.
-pub fn write_port_file_at(path: &Path, port: u16) -> io::Result<()> {
-    let bytes = serde_json::to_vec(&PortFile { port })?;
+pub fn write_port_file_at(path: &Path, port: u16, token: &str) -> io::Result<()> {
+    let bytes = serde_json::to_vec(&PortFile {
+        port,
+        token: token.to_string(),
+    })?;
     std::fs::write(path, bytes)
 }
 
-/// Write the control port to the well-known [`port_file_path`].
+/// Write the control endpoint to the well-known [`port_file_path`].
 ///
 /// # Errors
 /// Returns any serialization or I/O error.
-pub fn write_port_file(port: u16) -> io::Result<()> {
-    write_port_file_at(&port_file_path(), port)
+pub fn write_port_file(port: u16, token: &str) -> io::Result<()> {
+    write_port_file_at(&port_file_path(), port, token)
 }
 
-/// Read a control port from `path`, returning `None` if it is missing or malformed.
+/// Delete the discovery file (server shutdown) so a stale endpoint never points a future
+/// sidecar at a dead — or someone else's — port. Missing file is fine.
+pub fn remove_port_file() {
+    let _ = std::fs::remove_file(port_file_path());
+}
+
+/// Read an endpoint from `path`, returning `None` if it is missing or malformed.
 #[must_use]
-pub fn read_port_at(path: &Path) -> Option<u16> {
+pub fn read_endpoint_at(path: &Path) -> Option<(u16, String)> {
     let data = std::fs::read(path).ok()?;
     let pf: PortFile = serde_json::from_slice(&data).ok()?;
-    Some(pf.port)
+    Some((pf.port, pf.token))
 }
 
-/// Discover the control port: the `VUOOM_CONTROL_PORT` env var wins, else the port file.
+/// Discover the control endpoint: the `VUOOM_CONTROL_PORT` env var overrides the port
+/// (the token still comes from the discovery file, if present).
 #[must_use]
-pub fn discover_port() -> Option<u16> {
+pub fn discover_endpoint() -> Option<(u16, String)> {
+    let file = read_endpoint_at(&port_file_path());
     if let Ok(p) = std::env::var("VUOOM_CONTROL_PORT") {
         if let Ok(port) = p.trim().parse::<u16>() {
-            return Some(port);
+            let token = file.map(|(_, t)| t).unwrap_or_default();
+            return Some((port, token));
         }
     }
-    read_port_at(&port_file_path())
+    file
 }
 
 /// Write `msg` as a single newline-terminated JSON line and flush.
@@ -318,12 +578,21 @@ pub struct Client {
 }
 
 impl Client {
-    /// Connect to the control server on `127.0.0.1:port`.
+    /// Connect to the control server on `127.0.0.1:port` and authenticate with `token`.
+    ///
+    /// Applies [`CONNECT_TIMEOUT`] and [`READ_TIMEOUT`] so a hung server can never wedge
+    /// the sidecar (and with it, the agent's turn) forever.
     ///
     /// # Errors
     /// Returns an [`io::Error`] if the connection cannot be established.
-    pub fn connect(port: u16) -> io::Result<Self> {
-        let stream = TcpStream::connect(("127.0.0.1", port))?;
+    pub fn connect(port: u16, token: &str) -> io::Result<Self> {
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+        let stream = TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT)?;
+        stream.set_read_timeout(Some(READ_TIMEOUT))?;
+        let mut stream = stream;
+        stream.write_all(token.as_bytes())?;
+        stream.write_all(b"\n")?;
+        stream.flush()?;
         let reader = BufReader::new(stream.try_clone()?);
         Ok(Self { stream, reader })
     }
@@ -342,7 +611,9 @@ impl Client {
             .read_line(&mut line)
             .map_err(|e| e.to_string())?;
         if n == 0 {
-            return Err("control server closed the connection".into());
+            return Err(
+                "control server closed the connection (bad auth token or server shutdown)".into(),
+            );
         }
         serde_json::from_str(&line).map_err(|e| e.to_string())
     }
@@ -358,6 +629,7 @@ mod tests {
         let cases = vec![
             ControlRequest::Ping,
             ControlRequest::ScreenGeometry,
+            ControlRequest::Screenshot { width: Some(800) },
             ControlRequest::SetRegion {
                 x: Some(10),
                 y: Some(20),
@@ -371,19 +643,42 @@ mod tests {
                 h: None,
             },
             ControlRequest::SetZoomAmount { amount: 2.0 },
-            ControlRequest::SetAutoZoomOnClick { on: true },
-            ControlRequest::StartRecording,
+            ControlRequest::SetZoomStyle {
+                hold: Some(2.5),
+                pre_roll: None,
+                hl_zoom: Some(0.25),
+                hl_pan: None,
+            },
+            ControlRequest::StartRecording {
+                auto_zoom_on_click: Some(true),
+            },
             ControlRequest::StopRecording,
+            ControlRequest::CancelRecording,
             ControlRequest::SetPaused { paused: true },
-            ControlRequest::MoveCursor { x: -5, y: 100 },
+            ControlRequest::Status,
+            ControlRequest::MoveCursor {
+                x: -5,
+                y: 100,
+                duration_ms: Some(300),
+            },
             ControlRequest::Click {
                 x: 1,
                 y: 2,
                 button: Button::Right,
                 double: true,
+                glide_ms: None,
+            },
+            ControlRequest::Drag {
+                x1: 10,
+                y1: 20,
+                x2: 300,
+                y2: 400,
+                button: Button::Left,
+                duration_ms: Some(600),
             },
             ControlRequest::TypeText {
                 text: "hello world".into(),
+                cps: Some(20.0),
             },
             ControlRequest::KeyChord {
                 keys: vec!["ctrl".into(), "c".into()],
@@ -392,12 +687,42 @@ mod tests {
                 x: 3,
                 y: 4,
                 delta: -2,
+                step_ms: None,
             },
             ControlRequest::Seek { t: 1.5 },
             ControlRequest::ClipState,
             ControlRequest::GetFrames {
                 times: vec![0.0, 1.0, 2.5],
                 width: Some(800),
+            },
+            ControlRequest::AddZoom { t: 3.5 },
+            ControlRequest::UpdateZoom {
+                index: 1,
+                start: 2.0,
+                end: 4.5,
+                amount: 2.2,
+            },
+            ControlRequest::SetZoomFocus {
+                index: 0,
+                x: Some(0.25),
+                y: Some(0.75),
+            },
+            ControlRequest::RemoveZoom { index: 2 },
+            ControlRequest::AddCut {
+                start: 1.0,
+                end: 2.0,
+            },
+            ControlRequest::UpdateCut {
+                index: 0,
+                start: 1.5,
+                end: 2.5,
+            },
+            ControlRequest::RemoveCut { index: 0 },
+            ControlRequest::AutoSpeed { factor: 4.0 },
+            ControlRequest::ClearSpeed,
+            ControlRequest::SetTrim {
+                start: 0.5,
+                end: 9.5,
             },
             ControlRequest::ExportGif {
                 path: "C:/tmp/out.gif".into(),
@@ -411,6 +736,7 @@ mod tests {
                 width: None,
                 quality: 75,
             },
+            ControlRequest::ExportStatus { id: 7 },
             ControlRequest::EstimateGif {
                 fps: 20,
                 width: None,
@@ -423,6 +749,40 @@ mod tests {
             let back: ControlRequest = serde_json::from_str(&line).expect("deserialize");
             assert_eq!(req, back);
         }
+    }
+
+    /// New optional pacing fields may be omitted on the wire (older callers still work).
+    #[test]
+    fn optional_fields_default_when_missing() {
+        let click: ControlRequest =
+            serde_json::from_str(r#"{"op":"click","x":1,"y":2}"#).expect("parse");
+        assert_eq!(
+            click,
+            ControlRequest::Click {
+                x: 1,
+                y: 2,
+                button: Button::Left,
+                double: false,
+                glide_ms: None,
+            }
+        );
+        let start: ControlRequest =
+            serde_json::from_str(r#"{"op":"start_recording"}"#).expect("parse");
+        assert_eq!(
+            start,
+            ControlRequest::StartRecording {
+                auto_zoom_on_click: None
+            }
+        );
+        let text: ControlRequest =
+            serde_json::from_str(r#"{"op":"type_text","text":"hi"}"#).expect("parse");
+        assert_eq!(
+            text,
+            ControlRequest::TypeText {
+                text: "hi".into(),
+                cps: None
+            }
+        );
     }
 
     /// Every response variant must survive a JSON round-trip unchanged.
@@ -444,9 +804,32 @@ mod tests {
             }),
             ControlResponse::Clip(ClipInfo {
                 duration: 12.5,
-                zooms: 3,
-                cuts: 1,
-                speed_regions: 2,
+                output_duration: 9.75,
+                zooms: vec![ZoomSpan {
+                    start: 1.0,
+                    end: 3.5,
+                    amount: 1.8,
+                    focus: Some((0.3, 0.6)),
+                }],
+                cuts: vec![CutSpan {
+                    start: 5.0,
+                    end: 6.0,
+                }],
+                speeds: vec![SpeedSpan {
+                    start: 7.0,
+                    end: 9.0,
+                    factor: 4.0,
+                }],
+            }),
+            ControlResponse::Status(StatusInfo {
+                state: RecordState::Recording,
+                elapsed: Some(4.2),
+            }),
+            ControlResponse::Shot(FrameShot {
+                t: 0.0,
+                width: 800,
+                height: 450,
+                png_base64: "AAAA".into(),
             }),
             ControlResponse::Frames {
                 frames: vec![FrameShot {
@@ -456,6 +839,30 @@ mod tests {
                     png_base64: "AAAA".into(),
                 }],
             },
+            ControlResponse::Zooms {
+                zooms: vec![ZoomSpan {
+                    start: 0.5,
+                    end: 2.0,
+                    amount: 2.0,
+                    focus: None,
+                }],
+            },
+            ControlResponse::Cuts { cuts: vec![] },
+            ControlResponse::Speeds {
+                speeds: vec![SpeedSpan {
+                    start: 0.0,
+                    end: 1.0,
+                    factor: 2.0,
+                }],
+            },
+            ControlResponse::Job { id: 42 },
+            ControlResponse::Export(ExportState {
+                done: 120,
+                total: 400,
+                finished: false,
+                error: None,
+                path: "C:/tmp/out.gif".into(),
+            }),
             ControlResponse::Size { bytes: 1_234_567 },
         ];
         for resp in cases {
@@ -465,18 +872,31 @@ mod tests {
         }
     }
 
-    /// The port file round-trips, and a missing/garbage file reads back as `None`.
+    /// The endpoint file round-trips, and a missing/garbage file reads back as `None`.
     #[test]
     fn port_file_round_trips() {
         let dir = std::env::temp_dir();
         let path = dir.join(format!("vuoom-control-test-{}.json", std::process::id()));
         let _ = std::fs::remove_file(&path);
-        assert_eq!(read_port_at(&path), None);
-        write_port_file_at(&path, 54321).expect("write");
-        assert_eq!(read_port_at(&path), Some(54321));
+        assert_eq!(read_endpoint_at(&path), None);
+        write_port_file_at(&path, 54321, "cafe").expect("write");
+        assert_eq!(read_endpoint_at(&path), Some((54321, "cafe".to_string())));
         std::fs::write(&path, b"not json").expect("write garbage");
-        assert_eq!(read_port_at(&path), None);
+        assert_eq!(read_endpoint_at(&path), None);
+        // A pre-token file (port only) still reads, with an empty token.
+        std::fs::write(&path, br#"{"port": 1234}"#).expect("write old format");
+        assert_eq!(read_endpoint_at(&path), Some((1234, String::new())));
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// Tokens are 128-bit hex and unique across calls.
+    #[test]
+    fn tokens_are_hex_and_unique() {
+        let a = generate_token();
+        let b = generate_token();
+        assert_eq!(a.len(), 32);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two tokens must not collide");
     }
 
     /// `write_message` emits exactly one trailing newline and a parseable body.

--- a/crates/vuoom-control/src/lib.rs
+++ b/crates/vuoom-control/src/lib.rs
@@ -89,6 +89,17 @@ pub enum ControlRequest {
         hl_zoom: Option<f64>,
         /// Half-life (s) of the pan spring — smaller = snappier follow.
         hl_pan: Option<f64>,
+        /// Clicks within this gap (s) may merge into one zoom (clamped `0.1..=5.0`).
+        merge_gap: Option<f64>,
+        /// Clicks within this normalized distance of a cluster merge into it
+        /// (clamped `0.02..=1.0`).
+        merge_radius: Option<f64>,
+        /// Minimum seconds between the end of one zoom and the start of the next
+        /// (clamped `0.0..=10.0`).
+        min_rezoom_interval: Option<f64>,
+        /// Normalized half-extent the focus must leave before the pan retargets — jitter
+        /// rejection (clamped `0.0..=0.5`).
+        dead_zone: Option<f64>,
     },
     /// Begin capturing the screen + global input. `auto_zoom_on_click` defaults to `true`
     /// for agent recordings (the agent drives via clicks); the flag applies to **this**
@@ -191,9 +202,23 @@ pub enum ControlRequest {
         width: Option<u32>,
     },
     /// Insert a zoom segment starting at source time `t`; answered with the updated list.
+    /// Provide all four `rect_*` fields to frame a normalized region (fit-and-centre);
+    /// omit them for a plain cursor-following segment.
     AddZoom {
         /// Source-timeline start (seconds); the segment gets a default length.
         t: f64,
+        /// Rect left in `[0, 1]` (all four `rect_*` required together → Rect mode).
+        rect_x: Option<f64>,
+        /// Rect top in `[0, 1]`.
+        rect_y: Option<f64>,
+        /// Rect width in `[0, 1]`.
+        rect_w: Option<f64>,
+        /// Rect height in `[0, 1]`.
+        rect_h: Option<f64>,
+        /// Per-span zoom-*in* spring half-life (s); `None` = config default.
+        hl_zoom_in: Option<f64>,
+        /// Per-span zoom-*out* (release) spring half-life (s); `None` = default release.
+        hl_zoom_out: Option<f64>,
     },
     /// Retime / re-level the zoom at `index`; answered with the updated list.
     UpdateZoom {
@@ -205,15 +230,30 @@ pub enum ControlRequest {
         end: f64,
         /// New zoom multiplier (clamped to `[1.1, 4.0]`).
         amount: f64,
+        /// Per-span zoom-*in* half-life (s): `None` leaves it unchanged, a value `> 0`
+        /// sets it, and a value `<= 0` clears it back to the config default.
+        hl_zoom_in: Option<f64>,
+        /// Per-span zoom-*out* (release) half-life (s): same convention as `hl_zoom_in`.
+        hl_zoom_out: Option<f64>,
     },
-    /// Re-centre the zoom at `index`: fixed normalized focus, or follow the cursor again.
+    /// Re-centre the zoom at `index`: frame a normalized rect, hold a fixed focus, or follow
+    /// the cursor again. Precedence: all four `rect_*` → Rect mode; else `x`+`y` → Manual;
+    /// else Auto (follow the cursor).
     SetZoomFocus {
         /// Index into the sorted zoom list.
         index: usize,
-        /// Normalized focus x in `[0, 1]`; omit both to follow the cursor.
+        /// Normalized focus x in `[0, 1]`; omit both `x`/`y` (and the rect) to follow the cursor.
         x: Option<f64>,
         /// Normalized focus y in `[0, 1]`.
         y: Option<f64>,
+        /// Rect left in `[0, 1]` (all four `rect_*` required together → Rect mode).
+        rect_x: Option<f64>,
+        /// Rect top in `[0, 1]`.
+        rect_y: Option<f64>,
+        /// Rect width in `[0, 1]`.
+        rect_w: Option<f64>,
+        /// Rect height in `[0, 1]`.
+        rect_h: Option<f64>,
     },
     /// Delete the zoom at `index`; answered with the updated list.
     RemoveZoom {
@@ -320,7 +360,7 @@ pub struct RecordingSummary {
 }
 
 /// One zoom segment on the source timeline.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ZoomSpan {
     /// Segment start (source seconds).
     pub start: f64,
@@ -328,8 +368,13 @@ pub struct ZoomSpan {
     pub end: f64,
     /// Zoom multiplier while active.
     pub amount: f64,
-    /// Fixed normalized focus when manually set; `None` = the camera follows the cursor.
+    /// Focus point: the fixed point for `"manual"`, the rect centre for `"rect"`, and
+    /// `None` for `"auto"` (the camera follows the cursor).
     pub focus: Option<(f64, f64)>,
+    /// How this segment picks its focus: `"auto"`, `"manual"`, or `"rect"`.
+    pub mode: String,
+    /// The framed region `(x, y, w, h)` in normalized space when `mode == "rect"`, else `None`.
+    pub rect: Option<(f64, f64, f64, f64)>,
 }
 
 /// One cut (removed span) on the source timeline.
@@ -390,6 +435,11 @@ pub struct ClipInfo {
     pub cuts: Vec<CutSpan>,
     /// The speed regions, sorted by start.
     pub speeds: Vec<SpeedSpan>,
+    /// Coarsely-sampled camera path `(t, cx, cy, zoom)` on the **output timeline** (~4 Hz,
+    /// capped ~200 samples) so the agent can detect wander or poor framing without pulling
+    /// full frames. `t` is output-timeline seconds (consistent with `get_frames`/`seek`);
+    /// `cx`/`cy` are the normalized camera centre and `zoom` the multiplier.
+    pub camera: Vec<(f64, f64, f64, f64)>,
 }
 
 /// A single composited frame, returned for the agent to inspect.
@@ -648,6 +698,10 @@ mod tests {
                 pre_roll: None,
                 hl_zoom: Some(0.25),
                 hl_pan: None,
+                merge_gap: Some(1.2),
+                merge_radius: None,
+                min_rezoom_interval: Some(0.5),
+                dead_zone: Some(0.2),
             },
             ControlRequest::StartRecording {
                 auto_zoom_on_click: Some(true),
@@ -695,17 +749,31 @@ mod tests {
                 times: vec![0.0, 1.0, 2.5],
                 width: Some(800),
             },
-            ControlRequest::AddZoom { t: 3.5 },
+            ControlRequest::AddZoom {
+                t: 3.5,
+                rect_x: Some(0.1),
+                rect_y: Some(0.2),
+                rect_w: Some(0.3),
+                rect_h: Some(0.25),
+                hl_zoom_in: Some(0.4),
+                hl_zoom_out: None,
+            },
             ControlRequest::UpdateZoom {
                 index: 1,
                 start: 2.0,
                 end: 4.5,
                 amount: 2.2,
+                hl_zoom_in: Some(0.35),
+                hl_zoom_out: Some(0.0),
             },
             ControlRequest::SetZoomFocus {
                 index: 0,
                 x: Some(0.25),
                 y: Some(0.75),
+                rect_x: None,
+                rect_y: None,
+                rect_w: None,
+                rect_h: None,
             },
             ControlRequest::RemoveZoom { index: 2 },
             ControlRequest::AddCut {
@@ -785,6 +853,71 @@ mod tests {
         );
     }
 
+    /// Pre-existing callers omit the new zoom fields entirely — they must still parse, with
+    /// every new optional field defaulting to `None`.
+    #[test]
+    fn new_zoom_fields_default_when_missing() {
+        let add: ControlRequest =
+            serde_json::from_str(r#"{"op":"add_zoom","t":3.5}"#).expect("parse");
+        assert_eq!(
+            add,
+            ControlRequest::AddZoom {
+                t: 3.5,
+                rect_x: None,
+                rect_y: None,
+                rect_w: None,
+                rect_h: None,
+                hl_zoom_in: None,
+                hl_zoom_out: None,
+            }
+        );
+        let upd: ControlRequest = serde_json::from_str(
+            r#"{"op":"update_zoom","index":1,"start":2.0,"end":4.5,"amount":2.2}"#,
+        )
+        .expect("parse");
+        assert_eq!(
+            upd,
+            ControlRequest::UpdateZoom {
+                index: 1,
+                start: 2.0,
+                end: 4.5,
+                amount: 2.2,
+                hl_zoom_in: None,
+                hl_zoom_out: None,
+            }
+        );
+        let focus: ControlRequest =
+            serde_json::from_str(r#"{"op":"set_zoom_focus","index":0,"x":0.25,"y":0.75}"#)
+                .expect("parse");
+        assert_eq!(
+            focus,
+            ControlRequest::SetZoomFocus {
+                index: 0,
+                x: Some(0.25),
+                y: Some(0.75),
+                rect_x: None,
+                rect_y: None,
+                rect_w: None,
+                rect_h: None,
+            }
+        );
+        let style: ControlRequest =
+            serde_json::from_str(r#"{"op":"set_zoom_style","hold":2.0}"#).expect("parse");
+        assert_eq!(
+            style,
+            ControlRequest::SetZoomStyle {
+                hold: Some(2.0),
+                pre_roll: None,
+                hl_zoom: None,
+                hl_pan: None,
+                merge_gap: None,
+                merge_radius: None,
+                min_rezoom_interval: None,
+                dead_zone: None,
+            }
+        );
+    }
+
     /// Every response variant must survive a JSON round-trip unchanged.
     #[test]
     fn responses_round_trip() {
@@ -810,6 +943,8 @@ mod tests {
                     end: 3.5,
                     amount: 1.8,
                     focus: Some((0.3, 0.6)),
+                    mode: "rect".into(),
+                    rect: Some((0.2, 0.5, 0.2, 0.2)),
                 }],
                 cuts: vec![CutSpan {
                     start: 5.0,
@@ -820,6 +955,7 @@ mod tests {
                     end: 9.0,
                     factor: 4.0,
                 }],
+                camera: vec![(0.0, 0.5, 0.5, 1.0), (0.25, 0.4, 0.55, 1.8)],
             }),
             ControlResponse::Status(StatusInfo {
                 state: RecordState::Recording,
@@ -845,6 +981,8 @@ mod tests {
                     end: 2.0,
                     amount: 2.0,
                     focus: None,
+                    mode: "auto".into(),
+                    rect: None,
                 }],
             },
             ControlResponse::Cuts { cuts: vec![] },

--- a/crates/vuoom-control/tests/client_auth.rs
+++ b/crates/vuoom-control/tests/client_auth.rs
@@ -61,13 +61,23 @@ fn authenticated_client_round_trips() {
 fn wrong_token_is_rejected() {
     let token = vuoom_control::generate_token();
     let port = spawn_server(token);
-    // Connecting succeeds (TCP accepts), but the first call finds the socket closed.
+    // Connecting succeeds (TCP accepts), but the first call finds the socket gone: the
+    // server dropped it after the bad token. HOW that surfaces is platform-dependent —
+    // a clean EOF (n == 0 → our "closed the connection" message) on some stacks, or a
+    // raw connection reset/abort (WSAECONNABORTED / ECONNRESET) on Windows. The property
+    // under test is simply that a wrong token can never yield a successful call.
     let mut client = Client::connect(port, "wrong-token").expect("tcp connect");
     let err = client
         .call(&ControlRequest::Ping)
-        .expect_err("must be rejected");
+        .expect_err("wrong token must be rejected, never Ok");
+    let lower = err.to_lowercase();
     assert!(
-        err.contains("closed the connection"),
-        "unexpected error: {err}"
+        lower.contains("closed the connection")
+            || lower.contains("reset")
+            || lower.contains("aborted")
+            || lower.contains("broken pipe")
+            || lower.contains("10053")
+            || lower.contains("10054"),
+        "expected a connection-closed/reset error, got: {err}"
     );
 }

--- a/crates/vuoom-control/tests/client_auth.rs
+++ b/crates/vuoom-control/tests/client_auth.rs
@@ -1,0 +1,73 @@
+//! Integration: the blocking [`Client`] against a minimal in-process server that mimics
+//! the real control server's auth handshake — the first line of a connection must be the
+//! token, or the server silently drops the socket.
+
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+
+use vuoom_control::{write_message, Client, ControlRequest, ControlResponse};
+
+/// Spawn a tiny token-checking server; answers `Ping` with `Ok`.
+fn spawn_server(token: String) -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let token = token.clone();
+            std::thread::spawn(move || {
+                let Ok(mut writer) = stream.try_clone() else {
+                    return;
+                };
+                let mut reader = BufReader::new(stream);
+                let mut auth = String::new();
+                if reader.read_line(&mut auth).is_err() || auth.trim() != token {
+                    return; // drop unauthenticated peers, like the real server
+                }
+                for line in reader.lines() {
+                    let Ok(line) = line else { break };
+                    let resp = match serde_json::from_str::<ControlRequest>(&line) {
+                        Ok(ControlRequest::Ping) => ControlResponse::Ok,
+                        Ok(_) => ControlResponse::error("unsupported in test"),
+                        Err(e) => ControlResponse::error(format!("bad request: {e}")),
+                    };
+                    if write_message(&mut writer, &resp).is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    port
+}
+
+#[test]
+fn authenticated_client_round_trips() {
+    let token = vuoom_control::generate_token();
+    let port = spawn_server(token.clone());
+    let mut client = Client::connect(port, &token).expect("connect");
+    assert_eq!(
+        client.call(&ControlRequest::Ping).expect("call"),
+        ControlResponse::Ok
+    );
+    // The connection stays usable for further calls.
+    assert_eq!(
+        client.call(&ControlRequest::Ping).expect("second call"),
+        ControlResponse::Ok
+    );
+}
+
+#[test]
+fn wrong_token_is_rejected() {
+    let token = vuoom_control::generate_token();
+    let port = spawn_server(token);
+    // Connecting succeeds (TCP accepts), but the first call finds the socket closed.
+    let mut client = Client::connect(port, "wrong-token").expect("tcp connect");
+    let err = client
+        .call(&ControlRequest::Ping)
+        .expect_err("must be rejected");
+    assert!(
+        err.contains("closed the connection"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/vuoom-input/Cargo.toml
+++ b/crates/vuoom-input/Cargo.toml
@@ -19,5 +19,6 @@ windows = { version = "0.60", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_UI_HiDpi",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/vuoom-input/src/inject.rs
+++ b/crates/vuoom-input/src/inject.rs
@@ -1,14 +1,26 @@
-//! Synthetic input injection (mouse + keyboard) via `SendInput`.
+//! Synthetic input injection (mouse + keyboard) via `SendInput` — humanized.
 //!
-//! This is the half that lets an AI agent *drive* a target app: move/click/type/scroll.
+//! This is the half that lets an AI agent *drive* a target app: move/click/type/scroll/drag.
 //! Crucially, injected events are seen by the global low-level hook in [`crate::recorder`]
 //! exactly like hardware events (Vuoom does no injected-input filtering), so an injected
 //! click both operates the target app **and** drives the cinematic auto-zoom — one mechanism,
 //! two effects. See `docs/13-AI-Demo-Director-Research.md`.
 //!
+//! **Humanized motion.** The hardware cursor is baked into the captured pixels (WGC draws
+//! it), so an instant warp would *teleport* in the recording. Instead, moves glide along a
+//! minimum-jerk profile at ~125 Hz with a distance-scaled duration, clicks settle briefly
+//! before pressing, text types at a paced (jittered) cadence, and scrolls step one notch at
+//! a time. The glide also feeds a continuous stream of real move events to the hook, so the
+//! auto-zoom camera follows a path instead of a step function.
+//!
 //! Coordinates are **virtual-desktop physical pixels** (the capture/zoom space). The pure
-//! [`normalize_abs`] / [`key_to_vk`] helpers carry the fiddly math and are unit-tested;
-//! the `SendInput` wrappers are Windows-only and runtime-verified on a real machine.
+//! helpers ([`normalize_abs`], [`key_to_vk`], [`min_jerk`], [`glide_points`],
+//! [`glide_duration_ms`], [`jitter_factor`], [`is_extended_vk`]) carry the fiddly math and
+//! are unit-tested; the `SendInput` wrappers are Windows-only and runtime-verified.
+//!
+//! All injection functions return `Err` when Windows accepts fewer events than sent —
+//! the classic silent failure is UIPI blocking injection into an elevated window, and the
+//! agent must hear about it instead of recording a demo of nothing happening.
 
 /// Which mouse button to inject.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -41,12 +53,73 @@ pub fn normalize_abs(x: i32, y: i32, vx: i32, vy: i32, vw: i32, vh: i32) -> (i32
     (map(x, vx, vw), map(y, vy, vh))
 }
 
+/// Minimum-jerk ease: `s(p) = 10p³ − 15p⁴ + 6p⁵`, clamped to `[0, 1]`.
+///
+/// Starts and ends with zero velocity *and* zero acceleration — the profile human reaching
+/// movements follow, and why the glide reads as deliberate rather than mechanical.
+#[must_use]
+pub fn min_jerk(p: f64) -> f64 {
+    let p = p.clamp(0.0, 1.0);
+    p * p * p * (10.0 + p * (6.0 * p - 15.0))
+}
+
+/// Distance-scaled glide duration (ms): `clamp(150 + px/3, 200, 900)`.
+///
+/// Fitts-flavored: short hops are quick, cross-screen moves take under a second. Callers
+/// can always override with an explicit duration.
+#[must_use]
+pub fn glide_duration_ms(distance_px: f64) -> u32 {
+    let d = distance_px.max(0.0);
+    (150.0 + d / 3.0).clamp(200.0, 900.0).round() as u32
+}
+
+/// Sample `steps` points along the minimum-jerk path from `from` to `to`.
+///
+/// Returns exactly `steps.max(1)` points, excluding the start and ending precisely at `to`
+/// (so the final position is never off by rounding).
+#[must_use]
+pub fn glide_points(from: (i32, i32), to: (i32, i32), steps: u32) -> Vec<(i32, i32)> {
+    let n = steps.max(1);
+    (1..=n)
+        .map(|k| {
+            let s = min_jerk(f64::from(k) / f64::from(n));
+            (
+                (f64::from(from.0) + f64::from(to.0 - from.0) * s).round() as i32,
+                (f64::from(from.1) + f64::from(to.1 - from.1) * s).round() as i32,
+            )
+        })
+        .collect()
+}
+
+/// Deterministic per-index pacing jitter in `[1 − spread, 1 + spread]`.
+///
+/// Keystroke cadence with zero variance reads as robotic; true randomness would make
+/// recordings non-reproducible. A hash of the index gives both: humanlike spread, same
+/// timing every take.
+#[must_use]
+pub fn jitter_factor(i: usize, spread: f64) -> f64 {
+    let h = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    let unit = (h >> 11) as f64 / (1u64 << 53) as f64; // uniform 0..1
+    1.0 + spread * (2.0 * unit - 1.0)
+}
+
+/// Whether a virtual-key code is an *extended* key (arrows, nav cluster, Win keys).
+///
+/// These must be injected with `KEYEVENTF_EXTENDEDKEY`, or scan-code-aware apps
+/// (terminals, RDP, games) read e.g. "down arrow" as "numpad 2".
+#[must_use]
+pub fn is_extended_vk(vk: u16) -> bool {
+    // 0x21..=0x28: PgUp, PgDn, End, Home, arrows. 0x2D/0x2E: Insert/Delete. 0x5B/0x5C: Win.
+    matches!(vk, 0x21..=0x28 | 0x2D | 0x2E | 0x5B | 0x5C)
+}
+
 /// Resolve a key name (case-insensitive) to a Win32 virtual-key code.
 ///
 /// Accepts modifiers (`ctrl`/`control`, `shift`, `alt`, `win`/`super`/`cmd`/`meta`), common
 /// named keys (`enter`/`return`, `tab`, `esc`/`escape`, `space`, `backspace`, `delete`, arrows,
 /// `home`/`end`, `pageup`/`pagedown`), the function keys `f1`..`f12`, single letters `a`..`z`,
-/// and digits `0`..`9`. Returns `None` for anything else.
+/// digits `0`..`9`, and the OEM punctuation keys (`- = [ ] ; ' , . / \ ` `` and their names,
+/// e.g. `plus`/`minus`/`slash` — so chords like Ctrl+= work). Returns `None` for anything else.
 #[must_use]
 pub fn key_to_vk(name: &str) -> Option<u16> {
     let n = name.trim().to_ascii_lowercase();
@@ -70,6 +143,18 @@ pub fn key_to_vk(name: &str) -> Option<u16> {
         "end" => 0x23,
         "pageup" | "pgup" => 0x21,
         "pagedown" | "pgdn" => 0x22,
+        // OEM punctuation (US layout VKs) — chords like ctrl+= (browser zoom) need these.
+        "-" | "minus" | "dash" => 0xBD,
+        "=" | "equals" | "plus" => 0xBB,
+        "[" | "openbracket" => 0xDB,
+        "]" | "closebracket" => 0xDD,
+        ";" | "semicolon" => 0xBA,
+        "'" | "quote" | "apostrophe" => 0xDE,
+        "," | "comma" => 0xBC,
+        "." | "period" | "dot" => 0xBE,
+        "/" | "slash" => 0xBF,
+        "\\" | "backslash" => 0xDC,
+        "`" | "grave" | "backtick" => 0xC0,
         _ => return single_key_vk(&n),
     };
     Some(vk)
@@ -90,26 +175,46 @@ fn single_key_vk(n: &str) -> Option<u16> {
 }
 
 #[cfg(windows)]
-pub use platform::{click, key_chord, move_cursor, scroll, type_text, virtual_screen};
+pub use platform::{
+    click, cursor_pos, drag, key_chord, move_cursor, move_cursor_smooth, scroll, type_text,
+    virtual_screen,
+};
 
 #[cfg(windows)]
 mod platform {
-    use super::{normalize_abs, InjectButton};
+    use super::{
+        glide_duration_ms, glide_points, is_extended_vk, jitter_factor, normalize_abs, InjectButton,
+    };
     use std::mem::size_of;
+    use std::time::Duration;
+    use windows::Win32::Foundation::POINT;
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-        KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_LEFTDOWN,
-        MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE,
-        MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_VIRTUALDESK, MOUSEEVENTF_WHEEL,
-        MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
+        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEEVENTF_ABSOLUTE,
+        MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP,
+        MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_VIRTUALDESK,
+        MOUSEEVENTF_WHEEL, MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+        GetCursorPos, GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
         SM_YVIRTUALSCREEN,
     };
 
     /// One wheel "notch".
     const WHEEL_DELTA: i32 = 120;
+    /// Glide sample interval (~125 Hz) — smooth at any capture rate.
+    const GLIDE_STEP_MS: u64 = 8;
+    /// Pause after arriving at a target before pressing — reads as deliberate, and gives
+    /// the auto-zoom pre-roll a stationary point to zoom toward.
+    const SETTLE_MS: u64 = 120;
+    /// Button hold time for a click (hardware clicks are ~60–100 ms, never 0).
+    const PRESS_MS: u64 = 60;
+    /// Gap between the two presses of a double-click (well inside GetDoubleClickTime).
+    const DOUBLE_GAP_MS: u64 = 80;
+    /// Default gap between scroll notches.
+    const SCROLL_STEP_MS: u64 = 40;
+    /// Default typing speed when the caller does not specify one.
+    const DEFAULT_CPS: f64 = 15.0;
 
     /// The virtual-desktop bounds in physical pixels: `(x, y, width, height)`.
     #[must_use]
@@ -125,9 +230,37 @@ mod platform {
         }
     }
 
-    fn send(inputs: &[INPUT]) {
+    /// Current cursor position in virtual-desktop physical pixels.
+    #[must_use]
+    pub fn cursor_pos() -> (i32, i32) {
+        let mut pt = POINT::default();
+        // SAFETY: GetCursorPos writes into a valid POINT.
+        let _ = unsafe { GetCursorPos(&mut pt) };
+        (pt.x, pt.y)
+    }
+
+    /// Inject `inputs`, verifying Windows accepted every event.
+    ///
+    /// UIPI silently swallows injection into elevated windows — surfacing the short count
+    /// is the only way the agent learns its click never happened.
+    fn send(inputs: &[INPUT]) -> Result<(), String> {
         // SAFETY: `inputs` is a valid, initialized slice; cbSize is the element size.
-        let _sent = unsafe { SendInput(inputs, size_of::<INPUT>() as i32) };
+        let sent = unsafe { SendInput(inputs, size_of::<INPUT>() as i32) };
+        if sent as usize == inputs.len() {
+            Ok(())
+        } else {
+            Err(format!(
+                "input injection blocked ({sent}/{} events accepted) — is the target app \
+                 running elevated?",
+                inputs.len()
+            ))
+        }
+    }
+
+    fn sleep_ms(ms: u64) {
+        if ms > 0 {
+            std::thread::sleep(Duration::from_millis(ms));
+        }
     }
 
     fn mouse_event(flags: MOUSE_EVENT_FLAGS, dx: i32, dy: i32, data: i32) -> INPUT {
@@ -157,36 +290,130 @@ mod platform {
         )
     }
 
-    /// Move the cursor to `(x, y)` (physical px) without pressing a button.
-    pub fn move_cursor(x: i32, y: i32) {
-        send(&[abs_move(x, y)]);
+    /// Warp the cursor to `(x, y)` instantly, without pressing a button.
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn move_cursor(x: i32, y: i32) -> Result<(), String> {
+        send(&[abs_move(x, y)])
     }
 
-    /// Click at `(x, y)` with `button`; `double` issues a second down/up pair.
-    pub fn click(x: i32, y: i32, button: InjectButton, double: bool) {
-        let (down, up) = match button {
+    /// Glide the cursor to `(x, y)` along a minimum-jerk path.
+    ///
+    /// `duration_ms`: `None` = distance-scaled ([`glide_duration_ms`]); `Some(0)` = instant
+    /// warp. The glide emits real move events at ~125 Hz, so both the recorded pixels and
+    /// the auto-zoom camera see a smooth path.
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn move_cursor_smooth(x: i32, y: i32, duration_ms: Option<u32>) -> Result<(), String> {
+        let from = cursor_pos();
+        let dist = f64::from(x - from.0).hypot(f64::from(y - from.1));
+        let dur = duration_ms.unwrap_or_else(|| glide_duration_ms(dist));
+        if dur == 0 || dist < 1.0 {
+            return move_cursor(x, y);
+        }
+        let steps = (u64::from(dur) / GLIDE_STEP_MS).max(1) as u32;
+        for (px, py) in glide_points(from, (x, y), steps) {
+            send(&[abs_move(px, py)])?;
+            sleep_ms(GLIDE_STEP_MS);
+        }
+        Ok(())
+    }
+
+    fn button_flags(button: InjectButton) -> (MOUSE_EVENT_FLAGS, MOUSE_EVENT_FLAGS) {
+        match button {
             InjectButton::Left => (MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP),
             InjectButton::Right => (MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP),
             InjectButton::Middle => (MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP),
-        };
-        let mut inputs = vec![
-            abs_move(x, y),
-            mouse_event(down, 0, 0, 0),
-            mouse_event(up, 0, 0, 0),
-        ];
-        if double {
-            inputs.push(mouse_event(down, 0, 0, 0));
-            inputs.push(mouse_event(up, 0, 0, 0));
         }
-        send(&inputs);
     }
 
-    /// Scroll the wheel `delta` notches at `(x, y)` (positive = up).
-    pub fn scroll(x: i32, y: i32, delta: i32) {
-        send(&[
-            abs_move(x, y),
-            mouse_event(MOUSEEVENTF_WHEEL, 0, 0, delta * WHEEL_DELTA),
-        ]);
+    /// Glide to `(x, y)`, settle, and click; `double` issues a second press.
+    ///
+    /// `glide_ms` as in [`move_cursor_smooth`]. The settle + press pauses keep the cadence
+    /// of a hardware click and give the zoom pre-roll a stationary target.
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn click(
+        x: i32,
+        y: i32,
+        button: InjectButton,
+        double: bool,
+        glide_ms: Option<u32>,
+    ) -> Result<(), String> {
+        move_cursor_smooth(x, y, glide_ms)?;
+        sleep_ms(SETTLE_MS);
+        let (down, up) = button_flags(button);
+        send(&[mouse_event(down, 0, 0, 0)])?;
+        sleep_ms(PRESS_MS);
+        send(&[mouse_event(up, 0, 0, 0)])?;
+        if double {
+            sleep_ms(DOUBLE_GAP_MS);
+            send(&[mouse_event(down, 0, 0, 0)])?;
+            sleep_ms(PRESS_MS);
+            send(&[mouse_event(up, 0, 0, 0)])?;
+        }
+        Ok(())
+    }
+
+    /// Press-drag from `(x1, y1)` to `(x2, y2)`: glide there, hold `button`, glide the
+    /// pressed pointer along the path, release.
+    ///
+    /// `duration_ms` is the *dragging* portion; `None` = distance-scaled with a 400 ms
+    /// floor (drags read better slightly slower than free moves).
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn drag(
+        x1: i32,
+        y1: i32,
+        x2: i32,
+        y2: i32,
+        button: InjectButton,
+        duration_ms: Option<u32>,
+    ) -> Result<(), String> {
+        move_cursor_smooth(x1, y1, None)?;
+        sleep_ms(SETTLE_MS);
+        let (down, up) = button_flags(button);
+        send(&[mouse_event(down, 0, 0, 0)])?;
+        sleep_ms(100);
+        let dist = f64::from(x2 - x1).hypot(f64::from(y2 - y1));
+        let dur = duration_ms.unwrap_or_else(|| glide_duration_ms(dist).max(400));
+        let steps = (u64::from(dur.max(1)) / GLIDE_STEP_MS).max(1) as u32;
+        for (px, py) in glide_points((x1, y1), (x2, y2), steps) {
+            send(&[abs_move(px, py)])?;
+            sleep_ms(GLIDE_STEP_MS);
+        }
+        sleep_ms(80);
+        send(&[mouse_event(up, 0, 0, 0)])
+    }
+
+    /// Scroll `delta` notches at `(x, y)` (positive = up), one notch per step so smooth-
+    /// scrolling apps animate and the recording reads as intentional.
+    ///
+    /// `step_ms`: gap between notches (`None` = 40 ms; `Some(0)` = all at once).
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn scroll(x: i32, y: i32, delta: i32, step_ms: Option<u32>) -> Result<(), String> {
+        send(&[abs_move(x, y)])?;
+        if delta == 0 {
+            return Ok(());
+        }
+        let gap = step_ms.map_or(SCROLL_STEP_MS, u64::from);
+        if gap == 0 {
+            return send(&[mouse_event(MOUSEEVENTF_WHEEL, 0, 0, delta * WHEEL_DELTA)]);
+        }
+        let notch = if delta > 0 { WHEEL_DELTA } else { -WHEEL_DELTA };
+        for i in 0..delta.unsigned_abs() {
+            send(&[mouse_event(MOUSEEVENTF_WHEEL, 0, 0, notch)])?;
+            if i + 1 < delta.unsigned_abs() {
+                sleep_ms(gap);
+            }
+        }
+        Ok(())
     }
 
     fn key_unit(scan: u16, up: bool) -> INPUT {
@@ -209,11 +436,14 @@ mod platform {
     }
 
     fn vk_event(vk: u16, up: bool) -> INPUT {
-        let flags = if up {
+        let mut flags = if up {
             KEYEVENTF_KEYUP
         } else {
             KEYBD_EVENT_FLAGS(0)
         };
+        if is_extended_vk(vk) {
+            flags |= KEYEVENTF_EXTENDEDKEY;
+        }
         INPUT {
             r#type: INPUT_KEYBOARD,
             Anonymous: INPUT_0 {
@@ -228,32 +458,62 @@ mod platform {
         }
     }
 
-    /// Type `text` as Unicode into the focused control (one down/up per UTF-16 code unit).
-    pub fn type_text(text: &str) {
-        let mut inputs = Vec::with_capacity(text.len() * 2);
-        for unit in text.encode_utf16() {
-            inputs.push(key_unit(unit, false));
-            inputs.push(key_unit(unit, true));
+    /// Type `text` at a human cadence into the focused control.
+    ///
+    /// `cps`: characters per second (`None` = 15; clamped to `0.5..=200`). Each character
+    /// is followed by a deterministically jittered pause, so typing sustains the auto-zoom
+    /// hold like real typing does. `\n` and `\t` are pressed as real Enter/Tab (Unicode
+    /// 0x0A does not activate default buttons); `\r` is skipped.
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn type_text(text: &str, cps: Option<f64>) -> Result<(), String> {
+        let cps = match cps {
+            Some(c) if c.is_finite() && c > 0.0 => c.clamp(0.5, 200.0),
+            _ => DEFAULT_CPS,
+        };
+        let base_ms = 1000.0 / cps;
+        let mut units = [0u16; 2];
+        let mut first = true;
+        for (i, ch) in text.chars().enumerate() {
+            if ch == '\r' {
+                continue;
+            }
+            if !first {
+                sleep_ms((base_ms * jitter_factor(i, 0.3)).round() as u64);
+            }
+            first = false;
+            match ch {
+                '\n' => send(&[vk_event(0x0D, false), vk_event(0x0D, true)])?,
+                '\t' => send(&[vk_event(0x09, false), vk_event(0x09, true)])?,
+                _ => {
+                    let mut inputs = Vec::with_capacity(4);
+                    for &unit in ch.encode_utf16(&mut units).iter() {
+                        inputs.push(key_unit(unit, false));
+                        inputs.push(key_unit(unit, true));
+                    }
+                    send(&inputs)?;
+                }
+            }
         }
-        if !inputs.is_empty() {
-            send(&inputs);
-        }
+        Ok(())
     }
 
-    /// Press a chord of virtual-key codes: hold all in order, then release in reverse. Pass
-    /// modifiers first (e.g. Ctrl, then C).
-    pub fn key_chord(vks: &[u16]) {
+    /// Press a chord of virtual-key codes: hold all in order, brief pause, release in
+    /// reverse. Pass modifiers first (e.g. Ctrl, then C). Extended keys get the extended
+    /// flag automatically.
+    ///
+    /// # Errors
+    /// When Windows rejects the injection (see [`send`]).
+    pub fn key_chord(vks: &[u16]) -> Result<(), String> {
         if vks.is_empty() {
-            return;
+            return Ok(());
         }
-        let mut inputs = Vec::with_capacity(vks.len() * 2);
-        for &vk in vks {
-            inputs.push(vk_event(vk, false));
-        }
-        for &vk in vks.iter().rev() {
-            inputs.push(vk_event(vk, true));
-        }
-        send(&inputs);
+        let downs: Vec<INPUT> = vks.iter().map(|&vk| vk_event(vk, false)).collect();
+        send(&downs)?;
+        sleep_ms(50);
+        let ups: Vec<INPUT> = vks.iter().rev().map(|&vk| vk_event(vk, true)).collect();
+        send(&ups)
     }
 }
 
@@ -292,6 +552,81 @@ mod tests {
     }
 
     #[test]
+    fn min_jerk_is_monotone_and_bounded() {
+        assert_eq!(min_jerk(0.0), 0.0);
+        assert!((min_jerk(1.0) - 1.0).abs() < 1e-12);
+        assert!(
+            (min_jerk(0.5) - 0.5).abs() < 1e-12,
+            "odd symmetry at midpoint"
+        );
+        let mut prev = 0.0;
+        for k in 1..=100 {
+            let s = min_jerk(f64::from(k) / 100.0);
+            assert!(s >= prev, "min_jerk must be monotone");
+            assert!((0.0..=1.0).contains(&s));
+            prev = s;
+        }
+        // Clamps outside the unit interval.
+        assert_eq!(min_jerk(-1.0), 0.0);
+        assert!((min_jerk(2.0) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn min_jerk_starts_and_ends_slow() {
+        // Near the endpoints progress is much slower than linear (zero end velocities).
+        assert!(min_jerk(0.05) < 0.01);
+        assert!(min_jerk(0.95) > 0.99);
+    }
+
+    #[test]
+    fn glide_points_end_exactly_at_target() {
+        let pts = glide_points((0, 0), (1000, -500), 37);
+        assert_eq!(pts.len(), 37);
+        assert_eq!(*pts.last().unwrap(), (1000, -500));
+        // Progress along x is monotone for a monotone profile.
+        let mut prev = 0;
+        for &(x, _) in &pts {
+            assert!(x >= prev, "x must be monotone");
+            prev = x;
+        }
+        // Degenerate step count still yields the target.
+        assert_eq!(glide_points((3, 4), (3, 4), 0), vec![(3, 4)]);
+    }
+
+    #[test]
+    fn glide_duration_scales_with_distance() {
+        assert_eq!(glide_duration_ms(0.0), 200); // floor
+        assert_eq!(glide_duration_ms(3000.0), 900); // ceiling
+        let mid = glide_duration_ms(600.0);
+        assert!((300..=400).contains(&mid), "600px → ~350ms, got {mid}");
+    }
+
+    #[test]
+    fn jitter_is_deterministic_and_bounded() {
+        for i in 0..1000 {
+            let f = jitter_factor(i, 0.3);
+            assert!((0.7..=1.3).contains(&f), "i={i} f={f}");
+            assert_eq!(f, jitter_factor(i, 0.3), "must be deterministic");
+        }
+        // Not constant — at least two distinct values in a small window.
+        assert!((0..10)
+            .map(|i| jitter_factor(i, 0.3))
+            .any(|f| f != jitter_factor(0, 0.3)));
+    }
+
+    #[test]
+    fn extended_vk_set_covers_nav_cluster() {
+        for vk in [
+            0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x2D, 0x2E, 0x5B,
+        ] {
+            assert!(is_extended_vk(vk), "vk={vk:#x} must be extended");
+        }
+        for vk in [0x0D, 0x09, 0x41, 0x30, 0x11, 0x10] {
+            assert!(!is_extended_vk(vk), "vk={vk:#x} must not be extended");
+        }
+    }
+
+    #[test]
     fn key_names_map_to_expected_vks() {
         assert_eq!(key_to_vk("ctrl"), Some(0x11));
         assert_eq!(key_to_vk("CONTROL"), Some(0x11));
@@ -310,6 +645,24 @@ mod tests {
         assert_eq!(key_to_vk("9"), Some(0x39));
         assert_eq!(key_to_vk("f1"), Some(0x70));
         assert_eq!(key_to_vk("f12"), Some(0x7B));
+    }
+
+    #[test]
+    fn oem_punctuation_maps() {
+        assert_eq!(key_to_vk("="), Some(0xBB));
+        assert_eq!(key_to_vk("plus"), Some(0xBB));
+        assert_eq!(key_to_vk("-"), Some(0xBD));
+        assert_eq!(key_to_vk("minus"), Some(0xBD));
+        assert_eq!(key_to_vk("/"), Some(0xBF));
+        assert_eq!(key_to_vk("slash"), Some(0xBF));
+        assert_eq!(key_to_vk(","), Some(0xBC));
+        assert_eq!(key_to_vk("."), Some(0xBE));
+        assert_eq!(key_to_vk(";"), Some(0xBA));
+        assert_eq!(key_to_vk("'"), Some(0xDE));
+        assert_eq!(key_to_vk("["), Some(0xDB));
+        assert_eq!(key_to_vk("]"), Some(0xDD));
+        assert_eq!(key_to_vk("\\"), Some(0xDC));
+        assert_eq!(key_to_vk("`"), Some(0xC0));
     }
 
     #[test]

--- a/crates/vuoom-input/src/inject.rs
+++ b/crates/vuoom-input/src/inject.rs
@@ -155,9 +155,23 @@ pub fn key_to_vk(name: &str) -> Option<u16> {
         "/" | "slash" => 0xBF,
         "\\" | "backslash" => 0xDC,
         "`" | "grave" | "backtick" => 0xC0,
-        _ => return single_key_vk(&n),
+        // Numpad cluster — VK_ADD emits a literal `+` unshifted (unlike VK_OEM_PLUS above, which
+        // types `=`), so a chord like `["+"]` produces `+`. `multiply`/`subtract`/`divide`/`decimal`
+        // and `numpad0`..`numpad9` (0x60..0x69) round out the pad.
+        "+" | "add" => 0x6B,
+        "*" | "multiply" | "asterisk" | "star" => 0x6A,
+        "subtract" => 0x6D,
+        "divide" => 0x6F,
+        "decimal" => 0x6E,
+        _ => return numpad_vk(&n).or_else(|| single_key_vk(&n)),
     };
     Some(vk)
+}
+
+/// `numpad0`..`numpad9` → VK_NUMPAD0..VK_NUMPAD9 (0x60..0x69).
+fn numpad_vk(n: &str) -> Option<u16> {
+    let digit: u16 = n.strip_prefix("numpad")?.parse().ok()?;
+    (digit <= 9).then_some(0x60 + digit)
 }
 
 /// Letters, digits, and `f1`..`f12` — the single-token keys not in the named-key table.
@@ -663,6 +677,28 @@ mod tests {
         assert_eq!(key_to_vk("]"), Some(0xDD));
         assert_eq!(key_to_vk("\\"), Some(0xDC));
         assert_eq!(key_to_vk("`"), Some(0xC0));
+    }
+
+    #[test]
+    fn numpad_and_symbol_keys_map() {
+        // VK_ADD emits a literal `+` (VK_OEM_PLUS / "plus" stays 0xBB for ctrl+= chords).
+        assert_eq!(key_to_vk("+"), Some(0x6B));
+        assert_eq!(key_to_vk("add"), Some(0x6B));
+        assert_eq!(key_to_vk("plus"), Some(0xBB));
+        assert_eq!(key_to_vk("*"), Some(0x6A));
+        assert_eq!(key_to_vk("multiply"), Some(0x6A));
+        assert_eq!(key_to_vk("star"), Some(0x6A));
+        assert_eq!(key_to_vk("subtract"), Some(0x6D));
+        assert_eq!(key_to_vk("divide"), Some(0x6F));
+        assert_eq!(key_to_vk("decimal"), Some(0x6E));
+        // Numpad digit cluster (0x60..0x69).
+        assert_eq!(key_to_vk("numpad0"), Some(0x60));
+        assert_eq!(key_to_vk("numpad5"), Some(0x65));
+        assert_eq!(key_to_vk("numpad9"), Some(0x69));
+        assert_eq!(key_to_vk("NUMPAD9"), Some(0x69));
+        // Out-of-range / malformed numpad names fall through to None.
+        assert_eq!(key_to_vk("numpad10"), None);
+        assert_eq!(key_to_vk("numpad"), None);
     }
 
     #[test]

--- a/crates/vuoom-input/src/inject.rs
+++ b/crates/vuoom-input/src/inject.rs
@@ -1,0 +1,323 @@
+//! Synthetic input injection (mouse + keyboard) via `SendInput`.
+//!
+//! This is the half that lets an AI agent *drive* a target app: move/click/type/scroll.
+//! Crucially, injected events are seen by the global low-level hook in [`crate::recorder`]
+//! exactly like hardware events (Vuoom does no injected-input filtering), so an injected
+//! click both operates the target app **and** drives the cinematic auto-zoom — one mechanism,
+//! two effects. See `docs/13-AI-Demo-Director-Research.md`.
+//!
+//! Coordinates are **virtual-desktop physical pixels** (the capture/zoom space). The pure
+//! [`normalize_abs`] / [`key_to_vk`] helpers carry the fiddly math and are unit-tested;
+//! the `SendInput` wrappers are Windows-only and runtime-verified on a real machine.
+
+/// Which mouse button to inject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InjectButton {
+    /// Primary (left) button.
+    #[default]
+    Left,
+    /// Secondary (right) button.
+    Right,
+    /// Middle (wheel) button.
+    Middle,
+}
+
+/// Map a physical virtual-desktop pixel to a `SendInput` absolute coordinate (`0..=65535`).
+///
+/// `SendInput` with `MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK` expects the point
+/// normalized across the whole virtual desktop, where `65535` maps to the far edge. `vx`/`vy`
+/// are the desktop origin and `vw`/`vh` its size (from [`virtual_screen`]). The result is
+/// clamped into range; degenerate sizes collapse to `0`.
+#[must_use]
+pub fn normalize_abs(x: i32, y: i32, vx: i32, vy: i32, vw: i32, vh: i32) -> (i32, i32) {
+    let map = |v: i32, origin: i32, size: i32| -> i32 {
+        if size <= 1 {
+            return 0;
+        }
+        let rel = i64::from(v - origin);
+        let scaled = (rel * 65535) / i64::from(size - 1);
+        scaled.clamp(0, 65535) as i32
+    };
+    (map(x, vx, vw), map(y, vy, vh))
+}
+
+/// Resolve a key name (case-insensitive) to a Win32 virtual-key code.
+///
+/// Accepts modifiers (`ctrl`/`control`, `shift`, `alt`, `win`/`super`/`cmd`/`meta`), common
+/// named keys (`enter`/`return`, `tab`, `esc`/`escape`, `space`, `backspace`, `delete`, arrows,
+/// `home`/`end`, `pageup`/`pagedown`), the function keys `f1`..`f12`, single letters `a`..`z`,
+/// and digits `0`..`9`. Returns `None` for anything else.
+#[must_use]
+pub fn key_to_vk(name: &str) -> Option<u16> {
+    let n = name.trim().to_ascii_lowercase();
+    let vk = match n.as_str() {
+        "ctrl" | "control" => 0x11,
+        "shift" => 0x10,
+        "alt" | "menu" => 0x12,
+        "win" | "super" | "cmd" | "meta" => 0x5B,
+        "enter" | "return" => 0x0D,
+        "tab" => 0x09,
+        "esc" | "escape" => 0x1B,
+        "space" | "spacebar" => 0x20,
+        "backspace" | "back" => 0x08,
+        "delete" | "del" => 0x2E,
+        "insert" | "ins" => 0x2D,
+        "up" => 0x26,
+        "down" => 0x28,
+        "left" => 0x25,
+        "right" => 0x27,
+        "home" => 0x24,
+        "end" => 0x23,
+        "pageup" | "pgup" => 0x21,
+        "pagedown" | "pgdn" => 0x22,
+        _ => return single_key_vk(&n),
+    };
+    Some(vk)
+}
+
+/// Letters, digits, and `f1`..`f12` — the single-token keys not in the named-key table.
+fn single_key_vk(n: &str) -> Option<u16> {
+    let bytes = n.as_bytes();
+    match bytes {
+        [c @ b'a'..=b'z'] => Some(u16::from(c.to_ascii_uppercase())),
+        [d @ b'0'..=b'9'] => Some(u16::from(*d)),
+        [b'f', ..] => {
+            let num: u16 = n[1..].parse().ok()?;
+            (1..=12).contains(&num).then(|| 0x70 + (num - 1))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+pub use platform::{click, key_chord, move_cursor, scroll, type_text, virtual_screen};
+
+#[cfg(windows)]
+mod platform {
+    use super::{normalize_abs, InjectButton};
+    use std::mem::size_of;
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+        KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_LEFTDOWN,
+        MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE,
+        MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_VIRTUALDESK, MOUSEEVENTF_WHEEL,
+        MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+        SM_YVIRTUALSCREEN,
+    };
+
+    /// One wheel "notch".
+    const WHEEL_DELTA: i32 = 120;
+
+    /// The virtual-desktop bounds in physical pixels: `(x, y, width, height)`.
+    #[must_use]
+    pub fn virtual_screen() -> (i32, i32, i32, i32) {
+        // SAFETY: GetSystemMetrics is a pure read of system configuration.
+        unsafe {
+            (
+                GetSystemMetrics(SM_XVIRTUALSCREEN),
+                GetSystemMetrics(SM_YVIRTUALSCREEN),
+                GetSystemMetrics(SM_CXVIRTUALSCREEN),
+                GetSystemMetrics(SM_CYVIRTUALSCREEN),
+            )
+        }
+    }
+
+    fn send(inputs: &[INPUT]) {
+        // SAFETY: `inputs` is a valid, initialized slice; cbSize is the element size.
+        let _sent = unsafe { SendInput(inputs, size_of::<INPUT>() as i32) };
+    }
+
+    fn mouse_event(flags: MOUSE_EVENT_FLAGS, dx: i32, dy: i32, data: i32) -> INPUT {
+        INPUT {
+            r#type: INPUT_MOUSE,
+            Anonymous: INPUT_0 {
+                mi: MOUSEINPUT {
+                    dx,
+                    dy,
+                    mouseData: data as u32,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn abs_move(x: i32, y: i32) -> INPUT {
+        let (vx, vy, vw, vh) = virtual_screen();
+        let (ax, ay) = normalize_abs(x, y, vx, vy, vw, vh);
+        mouse_event(
+            MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK,
+            ax,
+            ay,
+            0,
+        )
+    }
+
+    /// Move the cursor to `(x, y)` (physical px) without pressing a button.
+    pub fn move_cursor(x: i32, y: i32) {
+        send(&[abs_move(x, y)]);
+    }
+
+    /// Click at `(x, y)` with `button`; `double` issues a second down/up pair.
+    pub fn click(x: i32, y: i32, button: InjectButton, double: bool) {
+        let (down, up) = match button {
+            InjectButton::Left => (MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP),
+            InjectButton::Right => (MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP),
+            InjectButton::Middle => (MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP),
+        };
+        let mut inputs = vec![
+            abs_move(x, y),
+            mouse_event(down, 0, 0, 0),
+            mouse_event(up, 0, 0, 0),
+        ];
+        if double {
+            inputs.push(mouse_event(down, 0, 0, 0));
+            inputs.push(mouse_event(up, 0, 0, 0));
+        }
+        send(&inputs);
+    }
+
+    /// Scroll the wheel `delta` notches at `(x, y)` (positive = up).
+    pub fn scroll(x: i32, y: i32, delta: i32) {
+        send(&[
+            abs_move(x, y),
+            mouse_event(MOUSEEVENTF_WHEEL, 0, 0, delta * WHEEL_DELTA),
+        ]);
+    }
+
+    fn key_unit(scan: u16, up: bool) -> INPUT {
+        let mut flags = KEYEVENTF_UNICODE;
+        if up {
+            flags |= KEYEVENTF_KEYUP;
+        }
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(0),
+                    wScan: scan,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn vk_event(vk: u16, up: bool) -> INPUT {
+        let flags = if up {
+            KEYEVENTF_KEYUP
+        } else {
+            KEYBD_EVENT_FLAGS(0)
+        };
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(vk),
+                    wScan: 0,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    /// Type `text` as Unicode into the focused control (one down/up per UTF-16 code unit).
+    pub fn type_text(text: &str) {
+        let mut inputs = Vec::with_capacity(text.len() * 2);
+        for unit in text.encode_utf16() {
+            inputs.push(key_unit(unit, false));
+            inputs.push(key_unit(unit, true));
+        }
+        if !inputs.is_empty() {
+            send(&inputs);
+        }
+    }
+
+    /// Press a chord of virtual-key codes: hold all in order, then release in reverse. Pass
+    /// modifiers first (e.g. Ctrl, then C).
+    pub fn key_chord(vks: &[u16]) {
+        if vks.is_empty() {
+            return;
+        }
+        let mut inputs = Vec::with_capacity(vks.len() * 2);
+        for &vk in vks {
+            inputs.push(vk_event(vk, false));
+        }
+        for &vk in vks.iter().rev() {
+            inputs.push(vk_event(vk, true));
+        }
+        send(&inputs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_maps_corners_to_full_range() {
+        // A 1920x1080 desktop at origin (0,0): top-left → 0, bottom-right → 65535.
+        assert_eq!(normalize_abs(0, 0, 0, 0, 1920, 1080), (0, 0));
+        assert_eq!(normalize_abs(1919, 1079, 0, 0, 1920, 1080), (65535, 65535));
+        // Centre is roughly half.
+        let (cx, cy) = normalize_abs(960, 540, 0, 0, 1920, 1080);
+        assert!((32000..34000).contains(&cx), "cx={cx}");
+        assert!((32000..34000).contains(&cy), "cy={cy}");
+    }
+
+    #[test]
+    fn normalize_handles_negative_origin_and_clamps() {
+        // Secondary monitor to the left: origin x = -1920, total width 3840.
+        let (ax, _) = normalize_abs(-1920, 0, -1920, 0, 3840, 1080);
+        assert_eq!(ax, 0);
+        // Out-of-bounds points clamp into range rather than overflow.
+        assert_eq!(
+            normalize_abs(10_000, 10_000, 0, 0, 1920, 1080),
+            (65535, 65535)
+        );
+        assert_eq!(normalize_abs(-50, -50, 0, 0, 1920, 1080), (0, 0));
+    }
+
+    #[test]
+    fn degenerate_screen_collapses_to_zero() {
+        assert_eq!(normalize_abs(5, 5, 0, 0, 0, 0), (0, 0));
+        assert_eq!(normalize_abs(5, 5, 0, 0, 1, 1), (0, 0));
+    }
+
+    #[test]
+    fn key_names_map_to_expected_vks() {
+        assert_eq!(key_to_vk("ctrl"), Some(0x11));
+        assert_eq!(key_to_vk("CONTROL"), Some(0x11));
+        assert_eq!(key_to_vk("shift"), Some(0x10));
+        assert_eq!(key_to_vk("enter"), Some(0x0D));
+        assert_eq!(key_to_vk("return"), Some(0x0D));
+        assert_eq!(key_to_vk("esc"), Some(0x1B));
+        assert_eq!(key_to_vk(" Tab "), Some(0x09));
+    }
+
+    #[test]
+    fn letters_digits_and_function_keys() {
+        assert_eq!(key_to_vk("a"), Some(0x41));
+        assert_eq!(key_to_vk("Z"), Some(0x5A));
+        assert_eq!(key_to_vk("0"), Some(0x30));
+        assert_eq!(key_to_vk("9"), Some(0x39));
+        assert_eq!(key_to_vk("f1"), Some(0x70));
+        assert_eq!(key_to_vk("f12"), Some(0x7B));
+    }
+
+    #[test]
+    fn unknown_keys_are_none() {
+        assert_eq!(key_to_vk(""), None);
+        assert_eq!(key_to_vk("f13"), None);
+        assert_eq!(key_to_vk("f0"), None);
+        assert_eq!(key_to_vk("hello"), None);
+        assert_eq!(key_to_vk("ab"), None);
+    }
+}

--- a/crates/vuoom-input/src/keys.rs
+++ b/crates/vuoom-input/src/keys.rs
@@ -56,7 +56,7 @@ pub fn key_name(vk: u16) -> Option<&'static str> {
         0x30..=0x39 => DIGITS[(vk - 0x30) as usize],
         0x41..=0x5A => LETTERS[(vk - 0x41) as usize],
         0x70..=0x7B => FKEYS[(vk - 0x70) as usize],
-        0xBB => "+",
+        0xBB => "=",
         0xBC => ",",
         0xBD => "-",
         0xBE => ".",

--- a/crates/vuoom-input/src/lib.rs
+++ b/crates/vuoom-input/src/lib.rs
@@ -18,8 +18,14 @@ pub use clock::Clock;
 pub use dpi::set_per_monitor_aware_v2;
 pub use event::{MouseButton, RawEvent, RawEventKind};
 #[cfg(windows)]
-pub use inject::{click, key_chord, move_cursor, scroll, type_text, virtual_screen};
-pub use inject::{key_to_vk, normalize_abs, InjectButton};
+pub use inject::{
+    click, cursor_pos, drag, key_chord, move_cursor, move_cursor_smooth, scroll, type_text,
+    virtual_screen,
+};
+pub use inject::{
+    glide_duration_ms, glide_points, is_extended_vk, jitter_factor, key_to_vk, min_jerk,
+    normalize_abs, InjectButton,
+};
 pub use keys::{is_standalone, key_name, modifier, Modifier};
 pub use normalize::{normalize, zoom_marks, CaptureRegion};
 #[cfg(windows)]

--- a/crates/vuoom-input/src/lib.rs
+++ b/crates/vuoom-input/src/lib.rs
@@ -8,6 +8,7 @@
 mod clock;
 mod dpi;
 mod event;
+mod inject;
 mod keys;
 mod normalize;
 #[cfg(windows)]
@@ -16,6 +17,9 @@ mod recorder;
 pub use clock::Clock;
 pub use dpi::set_per_monitor_aware_v2;
 pub use event::{MouseButton, RawEvent, RawEventKind};
+#[cfg(windows)]
+pub use inject::{click, key_chord, move_cursor, scroll, type_text, virtual_screen};
+pub use inject::{key_to_vk, normalize_abs, InjectButton};
 pub use keys::{is_standalone, key_name, modifier, Modifier};
 pub use normalize::{normalize, zoom_marks, CaptureRegion};
 #[cfg(windows)]

--- a/crates/vuoom-input/src/normalize.rs
+++ b/crates/vuoom-input/src/normalize.rs
@@ -56,7 +56,9 @@ pub fn normalize(
             pos,
             delta: f64::from(d),
         }),
-        RawEventKind::KeyDown(_) => Some(InputEvent::KeyType { t }),
+        // No caret pos from the raw hook: `pos` here is the mouse, which may sit far from the
+        // caret while typing — steering the camera toward it would be worse than staying put.
+        RawEventKind::KeyDown(_) => Some(InputEvent::KeyType { t, pos: None }),
         RawEventKind::ButtonUp(_) | RawEventKind::KeyUp(_) => None,
     }
 }

--- a/crates/vuoom-mcp/Cargo.toml
+++ b/crates/vuoom-mcp/Cargo.toml
@@ -1,0 +1,24 @@
+# Standalone MCP server (the "AI Demo Director" sidecar). An AI agent launches this over
+# stdio; it bridges MCP tool calls to Vuoom's localhost control server via vuoom-control.
+# See docs/13-AI-Demo-Director-Research.md.
+[package]
+name = "vuoom-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "vuoom-mcp"
+path = "src/main.rs"
+
+[dependencies]
+vuoom-control = { workspace = true }
+rmcp = { version = "1.7", features = ["transport-io"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = "1"
+anyhow = { workspace = true }

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -367,6 +367,33 @@ struct UpdateCutParams {
 struct AutoSpeedParams {
     /// Speed-up factor for idle stretches (1.5–16.0; 4.0 is a good default).
     factor: f64,
+    /// Minimum idle gap to skim, seconds (0.5–30.0; default 2.5). Idle gaps SHORTER than
+    /// this produce no speed region. Raise it to skim only the long dead stretches.
+    min_gap: Option<f64>,
+    /// Normal-speed lead-in kept after the last action, seconds (0.0–5.0; default 0.6).
+    lead: Option<f64>,
+    /// Normal-speed tail kept before the next action, seconds (0.0–5.0; default 0.4).
+    tail: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct PreviewParams {
+    /// Output-timeline start second to preview from (default 0 = clip start).
+    start: Option<f64>,
+    /// Output-timeline end second (default = end of the clip).
+    end: Option<f64>,
+    /// Preview frame rate, 1–10 (default 5). Lower it if the frame cap complains.
+    fps: Option<f64>,
+    /// Downscale width in px, 160–640 (default 480).
+    width: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct RegionToWindowParams {
+    /// Case-insensitive substring of the target window title (best/topmost match wins).
+    title: String,
+    /// Extra padding in px around the window, 0–200 (default 0).
+    padding: Option<i32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -850,17 +877,83 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Auto-detect idle stretches and speed them up by `factor` (replaces existing speed regions) — the one-call fix for 'the demo drags'. Returns the new speed regions."
+        description = "Auto-detect idle stretches and speed them up by `factor` (replaces existing speed regions) — the one-call fix for 'the demo drags'. Semantics: idle gaps SHORTER than min_gap (default 2.5s) produce no speed region; lead/tail seconds around actions (defaults 0.6/0.4s) stay at normal 1x speed. Tune min_gap/lead/tail instead of trial-and-erroring `factor`. Returns the new speed regions."
     )]
     async fn auto_speed(
         &self,
         Parameters(p): Parameters<AutoSpeedParams>,
     ) -> Result<CallToolResult, McpError> {
         match self
-            .call(ControlRequest::AutoSpeed { factor: p.factor })
+            .call(ControlRequest::AutoSpeed {
+                factor: p.factor,
+                min_gap: p.min_gap,
+                lead: p.lead,
+                tail: p.tail,
+            })
             .await?
         {
             ControlResponse::Speeds { speeds } => Ok(json(&speeds)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Cheap low-res animated preview to critique motion/pacing/easing BEFORE a full export — not a deliverable. Composites [start,end] (output-timeline seconds; default whole clip) at a low fps (default 5) into a small animated GIF you can watch. Capped at ~120 frames — if it complains, raise start / lower end / lower fps. Returns the GIF plus {frame_count,width,height,duration}."
+    )]
+    async fn preview_clip(
+        &self,
+        Parameters(p): Parameters<PreviewParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::PreviewClip {
+                start: p.start,
+                end: p.end,
+                fps: p.fps,
+                width: p.width,
+            })
+            .await?
+        {
+            ControlResponse::Preview(info) => {
+                let meta = serde_json::json!({
+                    "frame_count": info.frame_count,
+                    "width": info.width,
+                    "height": info.height,
+                    "duration": info.duration,
+                });
+                Ok(CallToolResult::success(vec![
+                    Content::text(serde_json::to_string(&meta).unwrap_or_default()),
+                    Content::image(info.gif_base64, "image/gif".to_string()),
+                ]))
+            }
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "List visible top-level windows with their physical-pixel bounds: [{title,x,y,w,h}], topmost first. Use it to find a window before set_region_to_window."
+    )]
+    async fn list_windows(&self) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::ListWindows).await? {
+            ControlResponse::Windows { windows } => Ok(json(&windows)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Snap the capture region to a window's CURRENT bounds (best case-insensitive title match) before start_recording — kills manual pixel-math. Optional padding px (0–200) around it. Returns the resolved region {x,y,w,h}. NOTE: this does NOT prevent other windows drawn ABOVE the target from appearing in the capture (true window-target capture is a future step) — move or minimize overlapping windows first."
+    )]
+    async fn set_region_to_window(
+        &self,
+        Parameters(p): Parameters<RegionToWindowParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::SetRegionToWindow {
+                title: p.title,
+                padding: p.padding,
+            })
+            .await?
+        {
+            ControlResponse::Region(r) => Ok(json(&r)),
             other => Err(unexpected(&other)),
         }
     }
@@ -1048,6 +1141,9 @@ mod tests {
             "export_gif",
             "export_mp4",
             "export_status",
+            "preview_clip",
+            "list_windows",
+            "set_region_to_window",
         ];
         for tool in expected {
             assert!(names.iter().any(|n| n == tool), "missing tool: {tool}");

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -160,6 +160,18 @@ struct ZoomStyleParams {
     hl_zoom: Option<f64>,
     /// Half-life (s) of the pan spring — smaller = snappier follow (default 0.22).
     hl_pan: Option<f64>,
+    /// Clicks within this gap (s) may merge into one zoom (0.1–5.0; default 0.8). Raise it
+    /// to fuse a burst of nearby clicks into a single steady zoom.
+    merge_gap: Option<f64>,
+    /// Clicks within this normalized distance merge into one cluster (0.02–1.0; default
+    /// 0.15). Larger = fewer, broader zooms.
+    merge_radius: Option<f64>,
+    /// Minimum seconds between one zoom ending and the next starting (0.0–10.0; default
+    /// 1.0). Raise it to stop rapid zoom in/out flicker.
+    min_rezoom_interval: Option<f64>,
+    /// How far (normalized) the focus must drift before the camera re-pans (0.0–0.5;
+    /// default 0.10). Larger = calmer, less twitchy following.
+    dead_zone: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -273,6 +285,21 @@ struct GetFramesParams {
 struct AddZoomParams {
     /// Source-timeline start (seconds); the segment gets a ~2 s default length.
     t: f64,
+    /// Frame a normalized region: provide ALL of rect_x/rect_y/rect_w/rect_h in [0,1] and
+    /// the camera fits-and-centres on it (the zoom only reduces to fit — never overshoots).
+    /// Frame the RESULT region — the display/value/fresh text — not the cursor. Omit for a
+    /// cursor-following zoom. rect_x = left.
+    rect_x: Option<f64>,
+    /// Rect top in [0,1].
+    rect_y: Option<f64>,
+    /// Rect width in [0,1].
+    rect_w: Option<f64>,
+    /// Rect height in [0,1].
+    rect_h: Option<f64>,
+    /// Zoom-in spring half-life (s), smaller = snappier; omit for the default.
+    hl_zoom_in: Option<f64>,
+    /// Zoom-out (release) spring half-life (s); omit for the default.
+    hl_zoom_out: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -285,16 +312,31 @@ struct UpdateZoomParams {
     end: f64,
     /// New zoom multiplier (1.1–4.0).
     amount: f64,
+    /// Zoom-in spring half-life (s): omit to leave unchanged, a value > 0 sets it (smaller =
+    /// snappier), a value <= 0 clears it back to the default.
+    hl_zoom_in: Option<f64>,
+    /// Zoom-out (release) spring half-life (s): same convention as hl_zoom_in.
+    hl_zoom_out: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ZoomFocusParams {
     /// Index into clip_state's sorted zoom list.
     index: usize,
-    /// Normalized focus x in [0,1]; omit BOTH x and y to follow the cursor again.
+    /// Normalized focus x in [0,1]; omit x, y AND the rect to follow the cursor again.
     x: Option<f64>,
     /// Normalized focus y in [0,1].
     y: Option<f64>,
+    /// Frame a normalized region instead of a point: provide ALL of
+    /// rect_x/rect_y/rect_w/rect_h in [0,1] and the camera fits-and-centres on it. Frame the
+    /// RESULT region — the display/value/fresh text — not the cursor. rect_x = left.
+    rect_x: Option<f64>,
+    /// Rect top in [0,1].
+    rect_y: Option<f64>,
+    /// Rect width in [0,1].
+    rect_w: Option<f64>,
+    /// Rect height in [0,1].
+    rect_h: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -436,7 +478,7 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Tune the auto-zoom FEEL for the NEXT recording (hold, pre_roll, spring half-lives). Omitted fields keep defaults; resets after each recording."
+        description = "Tune the auto-zoom FEEL for the NEXT recording: hold, pre_roll, spring half-lives (hl_zoom/hl_pan), and the merge/behaviour knobs merge_gap, merge_radius, min_rezoom_interval, dead_zone. Omitted fields keep defaults; resets after each recording. Use merge_gap/merge_radius to fuse click bursts into one steady zoom and min_rezoom_interval to stop zoom flicker."
     )]
     async fn set_zoom_style(
         &self,
@@ -447,6 +489,10 @@ impl VuoomMcp {
             pre_roll: p.pre_roll,
             hl_zoom: p.hl_zoom,
             hl_pan: p.hl_pan,
+            merge_gap: p.merge_gap,
+            merge_radius: p.merge_radius,
+            min_rezoom_interval: p.min_rezoom_interval,
+            dead_zone: p.dead_zone,
         })
         .await?;
         Ok(text("zoom style set"))
@@ -614,7 +660,7 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "The clip's full editable state: {duration, output_duration, zooms: [{start,end,amount,focus}], cuts, speeds}. Zoom/cut indices here are what the edit tools address. Call after stop_recording to know WHERE to sample frames."
+        description = "The clip's full editable state: {duration, output_duration, zooms: [{start,end,amount,focus,mode,rect}], cuts, speeds, camera: [[t,cx,cy,zoom],...]}. mode is auto|manual|rect; rect is the framed region when mode==rect. camera is the sampled path (~4 Hz, output-timeline t) — scan it for wander (cx/cy drifting) or bad framing before pulling frames. Zoom/cut indices here are what the edit tools address. Call after stop_recording to know WHERE to sample frames."
     )]
     async fn clip_state(&self) -> Result<CallToolResult, McpError> {
         match self.call(ControlRequest::ClipState).await? {
@@ -662,20 +708,31 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Insert a zoom segment at source time t (~2 s default length, follows the cursor). Returns the updated zoom list."
+        description = "Insert a zoom segment at source time t (~2 s default length). By default it follows the cursor; pass all four rect_* (normalized [0,1]) to frame a fixed region instead — frame the RESULT (the display/value/fresh text), not the cursor. Optional hl_zoom_in/hl_zoom_out set this span's spring feel. Returns the updated zoom list."
     )]
     async fn add_zoom(
         &self,
         Parameters(p): Parameters<AddZoomParams>,
     ) -> Result<CallToolResult, McpError> {
-        match self.call(ControlRequest::AddZoom { t: p.t }).await? {
+        match self
+            .call(ControlRequest::AddZoom {
+                t: p.t,
+                rect_x: p.rect_x,
+                rect_y: p.rect_y,
+                rect_w: p.rect_w,
+                rect_h: p.rect_h,
+                hl_zoom_in: p.hl_zoom_in,
+                hl_zoom_out: p.hl_zoom_out,
+            })
+            .await?
+        {
             ControlResponse::Zooms { zooms } => Ok(json(&zooms)),
             other => Err(unexpected(&other)),
         }
     }
 
     #[tool(
-        description = "Retime / re-level the zoom at `index` (from clip_state). Fixes 'zoom leaves too early' or 'too strong'. Returns the updated zoom list."
+        description = "Retime / re-level the zoom at `index` (from clip_state). Fixes 'zoom leaves too early' or 'too strong'. Optional hl_zoom_in/hl_zoom_out tune this span's spring feel (omit = unchanged, >0 = set, <=0 = clear to default). Returns the updated zoom list."
     )]
     async fn update_zoom(
         &self,
@@ -687,6 +744,8 @@ impl VuoomMcp {
                 start: p.start,
                 end: p.end,
                 amount: p.amount,
+                hl_zoom_in: p.hl_zoom_in,
+                hl_zoom_out: p.hl_zoom_out,
             })
             .await?
         {
@@ -696,7 +755,7 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Re-centre the zoom at `index`: pass normalized x,y in [0,1] to hold a fixed focus (fixes off-centre zooms), or omit both to follow the cursor again. Returns the updated zoom list."
+        description = "Re-frame the zoom at `index`. Precedence: pass all four rect_* (normalized [0,1]) to FRAME a region (fits-and-centres — best for showing a result: the display/value/fresh text, not the cursor); else pass x,y to hold a fixed point (fixes off-centre zooms); else omit everything to follow the cursor again. Returns the updated zoom list."
     )]
     async fn set_zoom_focus(
         &self,
@@ -707,6 +766,10 @@ impl VuoomMcp {
                 index: p.index,
                 x: p.x,
                 y: p.y,
+                rect_x: p.rect_x,
+                rect_y: p.rect_y,
+                rect_w: p.rect_w,
+                rect_h: p.rect_h,
             })
             .await?
         {

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -934,3 +934,65 @@ async fn main() -> anyhow::Result<()> {
     service.waiting().await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every tool the director workflow relies on must be registered in the router — the
+    /// `#[tool_handler]` macro wiring is otherwise invisible until an agent connects.
+    #[test]
+    fn router_lists_every_director_tool() {
+        let router = VuoomMcp::tool_router();
+        let names: Vec<String> = router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        let expected = [
+            "ping",
+            "screen_geometry",
+            "screenshot",
+            "status",
+            "set_region",
+            "set_zoom_amount",
+            "set_zoom_style",
+            "start_recording",
+            "stop_recording",
+            "cancel_recording",
+            "set_paused",
+            "move_cursor",
+            "click",
+            "drag",
+            "type_text",
+            "key_chord",
+            "scroll",
+            "wait",
+            "seek",
+            "clip_state",
+            "get_frames",
+            "add_zoom",
+            "update_zoom",
+            "set_zoom_focus",
+            "remove_zoom",
+            "add_cut",
+            "update_cut",
+            "remove_cut",
+            "auto_speed",
+            "clear_speed",
+            "set_trim",
+            "estimate_gif",
+            "export_gif",
+            "export_mp4",
+            "export_status",
+        ];
+        for tool in expected {
+            assert!(names.iter().any(|n| n == tool), "missing tool: {tool}");
+        }
+        assert_eq!(
+            names.len(),
+            expected.len(),
+            "unexpected extra tools: {names:?}"
+        );
+    }
+}

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -1,14 +1,16 @@
 //! Vuoom MCP server — the "AI Demo Director" sidecar.
 //!
 //! An AI agent (e.g. Claude) launches this binary over stdio. It exposes MCP **tools** that
-//! drive Vuoom's localhost control server (see [`vuoom_control`]): set the region, start/stop
-//! recording, inject mouse/keyboard into a target app, sample frames the agent can *see*, and
-//! export a GIF/MP4. The agent itself is the director and the verify loop — it drives, looks
-//! at the sampled frames, critiques, and re-records. See `docs/13-AI-Demo-Director-Research.md`.
+//! drive Vuoom's localhost control server (see [`vuoom_control`]): see the screen, set the
+//! region, start/stop recording, inject humanized mouse/keyboard into a target app, sample
+//! frames the agent can *see*, repair the clip (zooms/cuts/speed) without re-recording, and
+//! export a GIF/MP4 as a polled job. The agent itself is the director and the verify loop —
+//! it drives, looks at the sampled frames, critiques, edits, and re-records only when the
+//! content is wrong. See `docs/13-AI-Demo-Director-Research.md`.
 //!
 //! Vuoom must be running with `VUOOM_ENABLE_CONTROL=1` (the control server is opt-in for
-//! safety, since these tools inject real input). The port is discovered via
-//! [`vuoom_control::discover_port`].
+//! safety, since these tools inject real input). The endpoint + auth token are discovered
+//! via [`vuoom_control::discover_endpoint`].
 
 use std::sync::{Arc, Mutex};
 
@@ -21,6 +23,14 @@ use rmcp::{
 };
 use serde::Deserialize;
 use vuoom_control::{Button, Client, ControlRequest, ControlResponse};
+
+/// The most frames one `get_frames` call may sample — each is a vision-model image, so an
+/// over-eager request would flood the agent's context.
+const MAX_FRAMES_PER_CALL: usize = 16;
+/// Default downscale width for returned frames/screenshots (px) when none is given.
+const DEFAULT_FRAME_WIDTH: u32 = 800;
+/// The longest a single `wait` may sleep; call it repeatedly for longer waits.
+const MAX_WAIT_MS: u64 = 15_000;
 
 /// A lazily-(re)connected bridge to Vuoom's control server. Blocking I/O; tools call it via
 /// `spawn_blocking`. On a transport error the connection is dropped so the next call reconnects.
@@ -41,12 +51,12 @@ impl Bridge {
             .lock()
             .map_err(|_| "bridge lock poisoned".to_string())?;
         if guard.is_none() {
-            let port = vuoom_control::discover_port().ok_or_else(|| {
+            let (port, token) = vuoom_control::discover_endpoint().ok_or_else(|| {
                 "Vuoom control server not found — launch Vuoom with VUOOM_ENABLE_CONTROL=1"
                     .to_string()
             })?;
-            let client =
-                Client::connect(port).map_err(|e| format!("connect to Vuoom failed: {e}"))?;
+            let client = Client::connect(port, &token)
+                .map_err(|e| format!("connect to Vuoom failed: {e} — is Vuoom still running?"))?;
             *guard = Some(client);
         }
         let client = guard.as_mut().expect("connection present");
@@ -105,6 +115,12 @@ fn json(value: &impl serde::Serialize) -> CallToolResult {
     text(body)
 }
 
+/// A protocol reply of the wrong shape is a server bug — surface it as an error, never as
+/// tool output the agent might try to parse.
+fn unexpected(other: &ControlResponse) -> McpError {
+    McpError::internal_error(format!("unexpected control response: {other:?}"), None)
+}
+
 fn parse_button(s: Option<&str>) -> Button {
     match s.map(str::to_ascii_lowercase).as_deref() {
         Some("right") => Button::Right,
@@ -135,6 +151,18 @@ struct ZoomParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ZoomStyleParams {
+    /// Seconds of inactivity before the camera zooms back out (default 1.8).
+    hold: Option<f64>,
+    /// Seconds of anticipation before a click that the zoom-in begins (default 0.3).
+    pre_roll: Option<f64>,
+    /// Half-life (s) of the zoom spring — smaller = snappier (default 0.30).
+    hl_zoom: Option<f64>,
+    /// Half-life (s) of the pan spring — smaller = snappier follow (default 0.22).
+    hl_pan: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct StartParams {
     /// Seed a cinematic zoom on every click you inject (default true — the agent drives via
     /// clicks). Set false for a static recording where you'll add zooms manually.
@@ -142,11 +170,19 @@ struct StartParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-struct PointParams {
+struct ScreenshotParams {
+    /// Optional max width (px) to downscale the shot (default 800).
+    width: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoveParams {
     /// X in virtual-desktop physical px.
     x: i32,
     /// Y in virtual-desktop physical px.
     y: i32,
+    /// Glide duration in ms; omit for distance-scaled, 0 for an instant warp.
+    duration_ms: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -159,17 +195,38 @@ struct ClickParams {
     button: Option<String>,
     /// Double-click when true.
     double: Option<bool>,
+    /// Glide duration in ms; omit for distance-scaled (recommended), 0 for instant.
+    glide_ms: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct DragParams {
+    /// Drag start x (physical px).
+    x1: i32,
+    /// Drag start y (physical px).
+    y1: i32,
+    /// Drag end x (physical px).
+    x2: i32,
+    /// Drag end y (physical px).
+    y2: i32,
+    /// "left" (default), "right", or "middle".
+    button: Option<String>,
+    /// Duration of the dragging portion in ms; omit for distance-scaled.
+    duration_ms: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct TypeParams {
-    /// The Unicode text to type into the focused control.
+    /// The Unicode text to type into the focused control. \n and \t press real Enter/Tab.
     text: String,
+    /// Typing speed in characters per second (default ~15, humanlike jitter).
+    cps: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct KeyChordParams {
-    /// Key names, modifiers first, e.g. ["ctrl","c"] or ["enter"].
+    /// Key names, modifiers first, e.g. ["ctrl","c"] or ["enter"]. Punctuation like "=",
+    /// "-", "/" works too (so ["ctrl","="] zooms a browser).
     keys: Vec<String>,
 }
 
@@ -181,6 +238,8 @@ struct ScrollParams {
     y: i32,
     /// Wheel notches; positive scrolls up.
     delta: i32,
+    /// Gap between notches in ms (default 40; 0 = all at once).
+    step_ms: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -191,22 +250,81 @@ struct PausedParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct SeekParams {
-    /// Time from clip start, seconds.
+    /// Time from clip start, seconds (output timeline — what the export shows).
     t: f64,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct WaitParams {
-    /// Milliseconds to wait (e.g. to let the target app settle before the next action).
+    /// Milliseconds to wait (clamped to 15000 — call again for longer waits).
     ms: u64,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct GetFramesParams {
-    /// Times (seconds) to sample and return as PNG images for inspection.
+    /// Times (seconds, output timeline) to sample and return as PNG images — at most 16
+    /// per call. Use clip_state's zoom spans to pick times worth seeing.
     times: Vec<f64>,
-    /// Optional max width (px) to downscale each returned frame (keeps the payload small).
+    /// Optional max width (px) to downscale each returned frame (default 800).
     width: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AddZoomParams {
+    /// Source-timeline start (seconds); the segment gets a ~2 s default length.
+    t: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct UpdateZoomParams {
+    /// Index into clip_state's sorted zoom list.
+    index: usize,
+    /// New start (source seconds).
+    start: f64,
+    /// New end (source seconds).
+    end: f64,
+    /// New zoom multiplier (1.1–4.0).
+    amount: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ZoomFocusParams {
+    /// Index into clip_state's sorted zoom list.
+    index: usize,
+    /// Normalized focus x in [0,1]; omit BOTH x and y to follow the cursor again.
+    x: Option<f64>,
+    /// Normalized focus y in [0,1].
+    y: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct IndexParams {
+    /// Index into the relevant sorted list from clip_state.
+    index: usize,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SpanParams {
+    /// Start (source seconds).
+    start: f64,
+    /// End (source seconds).
+    end: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct UpdateCutParams {
+    /// Index into clip_state's sorted cut list.
+    index: usize,
+    /// New start (source seconds).
+    start: f64,
+    /// New end (source seconds).
+    end: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AutoSpeedParams {
+    /// Speed-up factor for idle stretches (1.5–16.0; 4.0 is a good default).
+    factor: f64,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -219,6 +337,12 @@ struct ExportParams {
     width: Option<u32>,
     /// Quality 1–100 (default 80).
     quality: Option<u8>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ExportStatusParams {
+    /// The job id returned by export_gif / export_mp4.
+    id: u64,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -247,7 +371,38 @@ impl VuoomMcp {
     async fn screen_geometry(&self) -> Result<CallToolResult, McpError> {
         match self.call(ControlRequest::ScreenGeometry).await? {
             ControlResponse::Geometry(g) => Ok(json(&g)),
-            other => Ok(text(format!("unexpected: {other:?}"))),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "See the screen RIGHT NOW (PNG of the recording monitor) — use before and between actions to locate what to click and to verify the UI reacted. Works whether or not a recording is running."
+    )]
+    async fn screenshot(
+        &self,
+        Parameters(p): Parameters<ScreenshotParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::Screenshot {
+                width: Some(p.width.unwrap_or(DEFAULT_FRAME_WIDTH)),
+            })
+            .await?
+        {
+            ControlResponse::Shot(shot) => Ok(CallToolResult::success(vec![
+                Content::text(format!("{}x{} px", shot.width, shot.height)),
+                Content::image(shot.png_base64, "image/png".to_string()),
+            ])),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "What is the engine doing? Returns {state: idle|recording|paused|clip_ready, elapsed}. Use to recover when unsure whether a recording is running."
+    )]
+    async fn status(&self) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::Status).await? {
+            ControlResponse::Status(s) => Ok(json(&s)),
+            other => Err(unexpected(&other)),
         }
     }
 
@@ -281,28 +436,52 @@ impl VuoomMcp {
     }
 
     #[tool(
+        description = "Tune the auto-zoom FEEL for the NEXT recording (hold, pre_roll, spring half-lives). Omitted fields keep defaults; resets after each recording."
+    )]
+    async fn set_zoom_style(
+        &self,
+        Parameters(p): Parameters<ZoomStyleParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetZoomStyle {
+            hold: p.hold,
+            pre_roll: p.pre_roll,
+            hl_zoom: p.hl_zoom,
+            hl_pan: p.hl_pan,
+        })
+        .await?;
+        Ok(text("zoom style set"))
+    }
+
+    #[tool(
         description = "Start recording the screen + global input. By default every click you inject seeds a cinematic auto-zoom; pass auto_zoom_on_click=false for a static recording."
     )]
     async fn start_recording(
         &self,
         Parameters(p): Parameters<StartParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.call(ControlRequest::SetAutoZoomOnClick {
-            on: p.auto_zoom_on_click.unwrap_or(true),
+        self.call(ControlRequest::StartRecording {
+            auto_zoom_on_click: p.auto_zoom_on_click,
         })
         .await?;
-        self.call(ControlRequest::StartRecording).await?;
         Ok(text("recording started"))
     }
 
     #[tool(
-        description = "Stop recording and build the editable clip. Returns {duration, frames, zooms}."
+        description = "Stop recording and build the editable clip. Returns {duration, frames, zooms}. Wait ~2500 ms after the last action first, so the final zoom-out completes."
     )]
     async fn stop_recording(&self) -> Result<CallToolResult, McpError> {
         match self.call(ControlRequest::StopRecording).await? {
             ControlResponse::Recording(s) => Ok(json(&s)),
-            other => Ok(text(format!("unexpected: {other:?}"))),
+            other => Err(unexpected(&other)),
         }
+    }
+
+    #[tool(
+        description = "Stop recording and DISCARD the take (no clip is built). The cheap way to abandon a botched take before re-recording."
+    )]
+    async fn cancel_recording(&self) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::CancelRecording).await?;
+        Ok(text("recording cancelled and discarded"))
     }
 
     #[tool(description = "Pause or resume the running recording (a paused span becomes a cut).")]
@@ -316,19 +495,23 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Move the cursor to (x, y) in physical px without clicking. Coordinates are virtual-desktop pixels (see screen_geometry)."
+        description = "Glide the cursor to (x, y) in physical px without clicking — a smooth, humanlike path (the cursor is visible in the recording). Coordinates are virtual-desktop pixels (see screen_geometry)."
     )]
     async fn move_cursor(
         &self,
-        Parameters(p): Parameters<PointParams>,
+        Parameters(p): Parameters<MoveParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.call(ControlRequest::MoveCursor { x: p.x, y: p.y })
-            .await?;
+        self.call(ControlRequest::MoveCursor {
+            x: p.x,
+            y: p.y,
+            duration_ms: p.duration_ms,
+        })
+        .await?;
         Ok(text("moved"))
     }
 
     #[tool(
-        description = "Click at (x, y) in physical px. Drives the target app AND triggers cinematic auto-zoom. button: left|right|middle; double: true for double-click."
+        description = "Click at (x, y) in physical px: the cursor GLIDES there smoothly, settles, then clicks — driving the target app AND triggering cinematic auto-zoom. button: left|right|middle; double: true for double-click."
     )]
     async fn click(
         &self,
@@ -339,22 +522,48 @@ impl VuoomMcp {
             y: p.y,
             button: parse_button(p.button.as_deref()),
             double: p.double.unwrap_or(false),
+            glide_ms: p.glide_ms,
         })
         .await?;
         Ok(text("clicked"))
     }
 
-    #[tool(description = "Type Unicode text into the currently focused control.")]
+    #[tool(
+        description = "Press-drag from (x1,y1) to (x2,y2): glide there, hold the button, drag along a smooth path, release. For sliders, drag-and-drop, text selection."
+    )]
+    async fn drag(
+        &self,
+        Parameters(p): Parameters<DragParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::Drag {
+            x1: p.x1,
+            y1: p.y1,
+            x2: p.x2,
+            y2: p.y2,
+            button: parse_button(p.button.as_deref()),
+            duration_ms: p.duration_ms,
+        })
+        .await?;
+        Ok(text("dragged"))
+    }
+
+    #[tool(
+        description = "Type Unicode text into the currently focused control at a human cadence (default ~15 chars/sec). \\n and \\t press real Enter/Tab."
+    )]
     async fn type_text(
         &self,
         Parameters(p): Parameters<TypeParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.call(ControlRequest::TypeText { text: p.text }).await?;
+        self.call(ControlRequest::TypeText {
+            text: p.text,
+            cps: p.cps,
+        })
+        .await?;
         Ok(text("typed"))
     }
 
     #[tool(
-        description = "Press a key chord, e.g. keys=[\"ctrl\",\"c\"] or [\"enter\"]. Modifiers first."
+        description = "Press a key chord, e.g. keys=[\"ctrl\",\"c\"], [\"enter\"], or [\"ctrl\",\"=\"]. Modifiers first."
     )]
     async fn key_chord(
         &self,
@@ -364,7 +573,9 @@ impl VuoomMcp {
         Ok(text("pressed"))
     }
 
-    #[tool(description = "Scroll the wheel at (x, y); positive delta scrolls up.")]
+    #[tool(
+        description = "Scroll the wheel at (x, y), one notch per step so the motion records smoothly; positive delta scrolls up."
+    )]
     async fn scroll(
         &self,
         Parameters(p): Parameters<ScrollParams>,
@@ -373,23 +584,27 @@ impl VuoomMcp {
             x: p.x,
             y: p.y,
             delta: p.delta,
+            step_ms: p.step_ms,
         })
         .await?;
         Ok(text("scrolled"))
     }
 
     #[tool(
-        description = "Wait N milliseconds — use between actions to let the target app settle (prefer this over assuming instant UI updates)."
+        description = "Wait N milliseconds (max 15000 per call) — use between actions so the target app can settle, and wait ~2500 ms before stop_recording so the final zoom-out completes."
     )]
     async fn wait(
         &self,
         Parameters(p): Parameters<WaitParams>,
     ) -> Result<CallToolResult, McpError> {
-        tokio::time::sleep(std::time::Duration::from_millis(p.ms)).await;
-        Ok(text("waited"))
+        let ms = p.ms.min(MAX_WAIT_MS);
+        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+        Ok(text(format!("waited {ms} ms")))
     }
 
-    #[tool(description = "Composite and publish the preview frame at time t (seconds).")]
+    #[tool(
+        description = "Composite and publish the preview frame at time t (seconds, output timeline)."
+    )]
     async fn seek(
         &self,
         Parameters(p): Parameters<SeekParams>,
@@ -399,26 +614,38 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Get a summary of the current clip: {duration, zooms, cuts, speed_regions}."
+        description = "The clip's full editable state: {duration, output_duration, zooms: [{start,end,amount,focus}], cuts, speeds}. Zoom/cut indices here are what the edit tools address. Call after stop_recording to know WHERE to sample frames."
     )]
     async fn clip_state(&self) -> Result<CallToolResult, McpError> {
         match self.call(ControlRequest::ClipState).await? {
             ControlResponse::Clip(c) => Ok(json(&c)),
-            other => Ok(text(format!("unexpected: {other:?}"))),
+            other => Err(unexpected(&other)),
         }
     }
 
     #[tool(
-        description = "Sample the clip at the given times (seconds) and return PNG images so you can SEE the output and critique it (zoom centring, legibility, timing). Sample sparsely, e.g. around each zoom."
+        description = "Sample the clip at the given OUTPUT-timeline times (seconds; max 16) and return PNG images — exactly what the export will show, so you can critique zoom centring, legibility, and timing. Sample around each zoom span from clip_state."
     )]
     async fn get_frames(
         &self,
         Parameters(p): Parameters<GetFramesParams>,
     ) -> Result<CallToolResult, McpError> {
+        if p.times.is_empty() {
+            return Err(McpError::invalid_params("times must not be empty", None));
+        }
+        if p.times.len() > MAX_FRAMES_PER_CALL {
+            return Err(McpError::invalid_params(
+                format!(
+                    "asked for {} frames; max {MAX_FRAMES_PER_CALL} per call — sample sparsely",
+                    p.times.len()
+                ),
+                None,
+            ));
+        }
         match self
             .call(ControlRequest::GetFrames {
                 times: p.times,
-                width: p.width,
+                width: Some(p.width.unwrap_or(DEFAULT_FRAME_WIDTH)),
             })
             .await?
         {
@@ -430,8 +657,170 @@ impl VuoomMcp {
                 }
                 Ok(CallToolResult::success(content))
             }
-            other => Ok(text(format!("unexpected: {other:?}"))),
+            other => Err(unexpected(&other)),
         }
+    }
+
+    #[tool(
+        description = "Insert a zoom segment at source time t (~2 s default length, follows the cursor). Returns the updated zoom list."
+    )]
+    async fn add_zoom(
+        &self,
+        Parameters(p): Parameters<AddZoomParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::AddZoom { t: p.t }).await? {
+            ControlResponse::Zooms { zooms } => Ok(json(&zooms)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Retime / re-level the zoom at `index` (from clip_state). Fixes 'zoom leaves too early' or 'too strong'. Returns the updated zoom list."
+    )]
+    async fn update_zoom(
+        &self,
+        Parameters(p): Parameters<UpdateZoomParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::UpdateZoom {
+                index: p.index,
+                start: p.start,
+                end: p.end,
+                amount: p.amount,
+            })
+            .await?
+        {
+            ControlResponse::Zooms { zooms } => Ok(json(&zooms)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Re-centre the zoom at `index`: pass normalized x,y in [0,1] to hold a fixed focus (fixes off-centre zooms), or omit both to follow the cursor again. Returns the updated zoom list."
+    )]
+    async fn set_zoom_focus(
+        &self,
+        Parameters(p): Parameters<ZoomFocusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::SetZoomFocus {
+                index: p.index,
+                x: p.x,
+                y: p.y,
+            })
+            .await?
+        {
+            ControlResponse::Zooms { zooms } => Ok(json(&zooms)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Delete the zoom at `index` (from clip_state) — e.g. a zoom on a misclick. Returns the updated zoom list."
+    )]
+    async fn remove_zoom(
+        &self,
+        Parameters(p): Parameters<IndexParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::RemoveZoom { index: p.index })
+            .await?
+        {
+            ControlResponse::Zooms { zooms } => Ok(json(&zooms)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Remove [start, end] (source seconds) from the output — dead air, loading spinners, mistakes. Returns the updated cut list."
+    )]
+    async fn add_cut(
+        &self,
+        Parameters(p): Parameters<SpanParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::AddCut {
+                start: p.start,
+                end: p.end,
+            })
+            .await?
+        {
+            ControlResponse::Cuts { cuts } => Ok(json(&cuts)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Retime the cut at `index` (from clip_state). Returns the updated cut list."
+    )]
+    async fn update_cut(
+        &self,
+        Parameters(p): Parameters<UpdateCutParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::UpdateCut {
+                index: p.index,
+                start: p.start,
+                end: p.end,
+            })
+            .await?
+        {
+            ControlResponse::Cuts { cuts } => Ok(json(&cuts)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Restore the cut at `index` (the section plays again). Returns the updated cut list."
+    )]
+    async fn remove_cut(
+        &self,
+        Parameters(p): Parameters<IndexParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::RemoveCut { index: p.index })
+            .await?
+        {
+            ControlResponse::Cuts { cuts } => Ok(json(&cuts)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Auto-detect idle stretches and speed them up by `factor` (replaces existing speed regions) — the one-call fix for 'the demo drags'. Returns the new speed regions."
+    )]
+    async fn auto_speed(
+        &self,
+        Parameters(p): Parameters<AutoSpeedParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::AutoSpeed { factor: p.factor })
+            .await?
+        {
+            ControlResponse::Speeds { speeds } => Ok(json(&speeds)),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(description = "Remove all speed regions (play everything at 1×).")]
+    async fn clear_speed(&self) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::ClearSpeed).await?;
+        Ok(text("speed regions cleared"))
+    }
+
+    #[tool(
+        description = "Trim the clip to [start, end] (source seconds) — drop an awkward first/last second without re-recording."
+    )]
+    async fn set_trim(
+        &self,
+        Parameters(p): Parameters<SpanParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetTrim {
+            start: p.start,
+            end: p.end,
+        })
+        .await?;
+        Ok(text("trim set"))
     }
 
     #[tool(description = "Estimate the GIF export size in bytes for the given settings.")]
@@ -448,47 +837,87 @@ impl VuoomMcp {
             .await?
         {
             ControlResponse::Size { bytes } => Ok(text(bytes.to_string())),
-            other => Ok(text(format!("unexpected: {other:?}"))),
+            other => Err(unexpected(&other)),
         }
     }
 
-    #[tool(description = "Export the edited clip to an animated GIF at the given absolute path.")]
+    #[tool(
+        description = "Start exporting the edited clip to an animated GIF (absolute path). Returns a job id IMMEDIATELY — poll export_status until finished:true."
+    )]
     async fn export_gif(
         &self,
         Parameters(p): Parameters<ExportParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.call(ControlRequest::ExportGif {
-            path: p.path.clone(),
-            fps: p.fps.unwrap_or(20),
-            width: p.width,
-            quality: p.quality.unwrap_or(80),
-        })
-        .await?;
-        Ok(text(format!("exported GIF to {}", p.path)))
+        match self
+            .call(ControlRequest::ExportGif {
+                path: p.path.clone(),
+                fps: p.fps.unwrap_or(20),
+                width: p.width,
+                quality: p.quality.unwrap_or(80),
+            })
+            .await?
+        {
+            ControlResponse::Job { id } => Ok(text(format!(
+                "export started: job {id} -> {} — poll export_status until finished",
+                p.path
+            ))),
+            other => Err(unexpected(&other)),
+        }
     }
 
-    #[tool(description = "Export the edited clip to an H.264 MP4 at the given absolute path.")]
+    #[tool(
+        description = "Start exporting the edited clip to an H.264 MP4 (absolute path). Returns a job id IMMEDIATELY — poll export_status until finished:true."
+    )]
     async fn export_mp4(
         &self,
         Parameters(p): Parameters<ExportParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.call(ControlRequest::ExportMp4 {
-            path: p.path.clone(),
-            fps: p.fps.unwrap_or(30),
-            width: p.width,
-            quality: p.quality.unwrap_or(80),
-        })
-        .await?;
-        Ok(text(format!("exported MP4 to {}", p.path)))
+        match self
+            .call(ControlRequest::ExportMp4 {
+                path: p.path.clone(),
+                fps: p.fps.unwrap_or(30),
+                width: p.width,
+                quality: p.quality.unwrap_or(80),
+            })
+            .await?
+        {
+            ControlResponse::Job { id } => Ok(text(format!(
+                "export started: job {id} -> {} — poll export_status until finished",
+                p.path
+            ))),
+            other => Err(unexpected(&other)),
+        }
+    }
+
+    #[tool(
+        description = "Poll an export job: {done, total, finished, error, path}. Wait ~1-2 s between polls; the file is complete when finished:true and error is null."
+    )]
+    async fn export_status(
+        &self,
+        Parameters(p): Parameters<ExportStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::ExportStatus { id: p.id }).await? {
+            ControlResponse::Export(state) => Ok(json(&state)),
+            other => Err(unexpected(&other)),
+        }
     }
 }
 
 /// Guidance shown to the agent on connect.
-const INSTRUCTIONS: &str = "Vuoom AI Demo Director. Workflow: (1) screen_geometry, \
-    (2) set_region/set_zoom_amount, (3) start_recording, (4) drive the target app with \
-    click/type/key_chord/scroll (clicks also trigger cinematic auto-zoom) using wait between \
-    steps, (5) stop_recording, (6) get_frames to SEE the result and critique it, re-recording \
-    if needed, (7) export_gif/export_mp4. Vuoom must run with VUOOM_ENABLE_CONTROL=1.";
+const INSTRUCTIONS: &str = "Vuoom AI Demo Director — record cinematic, auto-zoomed demo \
+    GIFs/MP4s of a Windows app you drive. Vuoom must run with VUOOM_ENABLE_CONTROL=1.\n\
+    Workflow: (1) screen_geometry, then screenshot to SEE the screen and locate targets. \
+    (2) set_region / set_zoom_amount (2.0 is a good default). (3) start_recording. \
+    (4) Drive the target: click / type_text / key_chord / scroll / drag — the cursor glides \
+    smoothly and clicks trigger cinematic auto-zoom. Rhythm: wait 800–1500 ms after each \
+    action so the UI reacts on camera; screenshot mid-take if unsure what state the app is \
+    in; finish with wait 2500 so the final zoom-out completes. (5) stop_recording (or \
+    cancel_recording to discard a botched take). (6) clip_state for the zoom spans, then \
+    get_frames at times around each span to SEE the result; critique centring, legibility, \
+    dead air. (7) REPAIR in place — update_zoom / set_zoom_focus / remove_zoom / add_cut / \
+    auto_speed / set_trim; re-record only when the on-screen content itself is wrong, and \
+    cap the loop at 3–4 takes. (8) estimate_gif, then export_gif / export_mp4 and poll \
+    export_status until finished.";
 
 #[tool_handler]
 impl ServerHandler for VuoomMcp {

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -1,0 +1,493 @@
+//! Vuoom MCP server — the "AI Demo Director" sidecar.
+//!
+//! An AI agent (e.g. Claude) launches this binary over stdio. It exposes MCP **tools** that
+//! drive Vuoom's localhost control server (see [`vuoom_control`]): set the region, start/stop
+//! recording, inject mouse/keyboard into a target app, sample frames the agent can *see*, and
+//! export a GIF/MP4. The agent itself is the director and the verify loop — it drives, looks
+//! at the sampled frames, critiques, and re-records. See `docs/13-AI-Demo-Director-Research.md`.
+//!
+//! Vuoom must be running with `VUOOM_ENABLE_CONTROL=1` (the control server is opt-in for
+//! safety, since these tools inject real input). The port is discovered via
+//! [`vuoom_control::discover_port`].
+
+use std::sync::{Arc, Mutex};
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    schemars, tool, tool_handler, tool_router,
+    transport::stdio,
+    ErrorData as McpError, ServerHandler, ServiceExt,
+};
+use serde::Deserialize;
+use vuoom_control::{Button, Client, ControlRequest, ControlResponse};
+
+/// A lazily-(re)connected bridge to Vuoom's control server. Blocking I/O; tools call it via
+/// `spawn_blocking`. On a transport error the connection is dropped so the next call reconnects.
+struct Bridge {
+    conn: Mutex<Option<Client>>,
+}
+
+impl Bridge {
+    fn new() -> Self {
+        Self {
+            conn: Mutex::new(None),
+        }
+    }
+
+    fn call_blocking(&self, req: &ControlRequest) -> Result<ControlResponse, String> {
+        let mut guard = self
+            .conn
+            .lock()
+            .map_err(|_| "bridge lock poisoned".to_string())?;
+        if guard.is_none() {
+            let port = vuoom_control::discover_port().ok_or_else(|| {
+                "Vuoom control server not found — launch Vuoom with VUOOM_ENABLE_CONTROL=1"
+                    .to_string()
+            })?;
+            let client =
+                Client::connect(port).map_err(|e| format!("connect to Vuoom failed: {e}"))?;
+            *guard = Some(client);
+        }
+        let client = guard.as_mut().expect("connection present");
+        match client.call(req) {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                *guard = None; // force a reconnect next time
+                Err(e)
+            }
+        }
+    }
+}
+
+/// The MCP server: holds the tool router and the bridge to Vuoom.
+#[derive(Clone)]
+struct VuoomMcp {
+    // Read at runtime by the `#[tool_handler]`-generated `call_tool`/`list_tools` (verified by a
+    // tools/list smoke test); the dead-code lint can't see through the macro, so allow it.
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Self>,
+    bridge: Arc<Bridge>,
+}
+
+impl VuoomMcp {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            bridge: Arc::new(Bridge::new()),
+        }
+    }
+
+    /// Run one control request on the blocking pool, mapping failures to MCP errors and a
+    /// control-level `Error` response into an MCP error too (so the agent sees the reason).
+    async fn call(&self, req: ControlRequest) -> Result<ControlResponse, McpError> {
+        let bridge = Arc::clone(&self.bridge);
+        let resp = tokio::task::spawn_blocking(move || bridge.call_blocking(&req))
+            .await
+            .map_err(|e| McpError::internal_error(format!("join error: {e}"), None))?
+            .map_err(|e| McpError::internal_error(e, None))?;
+        match resp {
+            ControlResponse::Error { message } => Err(McpError::internal_error(message, None)),
+            other => Ok(other),
+        }
+    }
+}
+
+/// `Content::text` for a plain string.
+fn text(s: impl Into<String>) -> CallToolResult {
+    CallToolResult::success(vec![Content::text(s.into())])
+}
+
+/// `Content::text` for any serializable payload, as compact JSON.
+fn json(value: &impl serde::Serialize) -> CallToolResult {
+    let body =
+        serde_json::to_string(value).unwrap_or_else(|e| format!("{{\"serialize_error\":\"{e}\"}}"));
+    text(body)
+}
+
+fn parse_button(s: Option<&str>) -> Button {
+    match s.map(str::to_ascii_lowercase).as_deref() {
+        Some("right") => Button::Right,
+        Some("middle") => Button::Middle,
+        _ => Button::Left,
+    }
+}
+
+// ── Tool parameter structs ───────────────────────────────────────────────────────
+
+/// Capture-region rectangle (physical px); omit fields for full screen.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct RegionParams {
+    /// Left edge (physical px). Omit for full screen.
+    x: Option<u32>,
+    /// Top edge (physical px).
+    y: Option<u32>,
+    /// Width (physical px).
+    w: Option<u32>,
+    /// Height (physical px).
+    h: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ZoomParams {
+    /// Zoom multiplier, 1.0 (off) to 4.0.
+    amount: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct PointParams {
+    /// X in virtual-desktop physical px.
+    x: i32,
+    /// Y in virtual-desktop physical px.
+    y: i32,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ClickParams {
+    /// X in virtual-desktop physical px.
+    x: i32,
+    /// Y in virtual-desktop physical px.
+    y: i32,
+    /// "left" (default), "right", or "middle".
+    button: Option<String>,
+    /// Double-click when true.
+    double: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct TypeParams {
+    /// The Unicode text to type into the focused control.
+    text: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct KeyChordParams {
+    /// Key names, modifiers first, e.g. ["ctrl","c"] or ["enter"].
+    keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ScrollParams {
+    /// X in virtual-desktop physical px.
+    x: i32,
+    /// Y in virtual-desktop physical px.
+    y: i32,
+    /// Wheel notches; positive scrolls up.
+    delta: i32,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct PausedParams {
+    /// True to pause, false to resume.
+    paused: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SeekParams {
+    /// Time from clip start, seconds.
+    t: f64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct WaitParams {
+    /// Milliseconds to wait (e.g. to let the target app settle before the next action).
+    ms: u64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GetFramesParams {
+    /// Times (seconds) to sample and return as PNG images for inspection.
+    times: Vec<f64>,
+    /// Optional max width (px) to downscale each returned frame (keeps the payload small).
+    width: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ExportParams {
+    /// Absolute output path.
+    path: String,
+    /// Output frame rate (e.g. 20 for a README GIF).
+    fps: Option<u32>,
+    /// Optional max width (px).
+    width: Option<u32>,
+    /// Quality 1–100 (default 80).
+    quality: Option<u8>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EstimateParams {
+    /// Output frame rate.
+    fps: Option<u32>,
+    /// Optional max width (px).
+    width: Option<u32>,
+    /// Quality 1–100 (default 80).
+    quality: Option<u8>,
+}
+
+// ── Tools ────────────────────────────────────────────────────────────────────────
+
+#[tool_router]
+impl VuoomMcp {
+    #[tool(description = "Check that the Vuoom control server is reachable.")]
+    async fn ping(&self) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::Ping).await?;
+        Ok(text("ok"))
+    }
+
+    #[tool(
+        description = "Get the virtual-desktop bounds (x, y, width, height) in physical pixels. Use this first to reason about where to click."
+    )]
+    async fn screen_geometry(&self) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::ScreenGeometry).await? {
+            ControlResponse::Geometry(g) => Ok(json(&g)),
+            other => Ok(text(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    #[tool(
+        description = "Set the capture region (physical px) for the NEXT recording. Omit x/y/w/h for full screen. Call before start_recording."
+    )]
+    async fn set_region(
+        &self,
+        Parameters(p): Parameters<RegionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetRegion {
+            x: p.x,
+            y: p.y,
+            w: p.w,
+            h: p.h,
+        })
+        .await?;
+        Ok(text("region set"))
+    }
+
+    #[tool(
+        description = "Set the auto-zoom multiplier (1.0 = off, up to 4.0) for the NEXT recording. Call before start_recording."
+    )]
+    async fn set_zoom_amount(
+        &self,
+        Parameters(p): Parameters<ZoomParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetZoomAmount { amount: p.amount })
+            .await?;
+        Ok(text("zoom amount set"))
+    }
+
+    #[tool(
+        description = "Start recording the screen + global input. Auto-zoom is planned from the clicks you inject during the recording."
+    )]
+    async fn start_recording(&self) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::StartRecording).await?;
+        Ok(text("recording started"))
+    }
+
+    #[tool(
+        description = "Stop recording and build the editable clip. Returns {duration, frames, zooms}."
+    )]
+    async fn stop_recording(&self) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::StopRecording).await? {
+            ControlResponse::Recording(s) => Ok(json(&s)),
+            other => Ok(text(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    #[tool(description = "Pause or resume the running recording (a paused span becomes a cut).")]
+    async fn set_paused(
+        &self,
+        Parameters(p): Parameters<PausedParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetPaused { paused: p.paused })
+            .await?;
+        Ok(text("ok"))
+    }
+
+    #[tool(
+        description = "Move the cursor to (x, y) in physical px without clicking. Coordinates are virtual-desktop pixels (see screen_geometry)."
+    )]
+    async fn move_cursor(
+        &self,
+        Parameters(p): Parameters<PointParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::MoveCursor { x: p.x, y: p.y })
+            .await?;
+        Ok(text("moved"))
+    }
+
+    #[tool(
+        description = "Click at (x, y) in physical px. Drives the target app AND triggers cinematic auto-zoom. button: left|right|middle; double: true for double-click."
+    )]
+    async fn click(
+        &self,
+        Parameters(p): Parameters<ClickParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::Click {
+            x: p.x,
+            y: p.y,
+            button: parse_button(p.button.as_deref()),
+            double: p.double.unwrap_or(false),
+        })
+        .await?;
+        Ok(text("clicked"))
+    }
+
+    #[tool(description = "Type Unicode text into the currently focused control.")]
+    async fn type_text(
+        &self,
+        Parameters(p): Parameters<TypeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::TypeText { text: p.text }).await?;
+        Ok(text("typed"))
+    }
+
+    #[tool(
+        description = "Press a key chord, e.g. keys=[\"ctrl\",\"c\"] or [\"enter\"]. Modifiers first."
+    )]
+    async fn key_chord(
+        &self,
+        Parameters(p): Parameters<KeyChordParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::KeyChord { keys: p.keys }).await?;
+        Ok(text("pressed"))
+    }
+
+    #[tool(description = "Scroll the wheel at (x, y); positive delta scrolls up.")]
+    async fn scroll(
+        &self,
+        Parameters(p): Parameters<ScrollParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::Scroll {
+            x: p.x,
+            y: p.y,
+            delta: p.delta,
+        })
+        .await?;
+        Ok(text("scrolled"))
+    }
+
+    #[tool(
+        description = "Wait N milliseconds — use between actions to let the target app settle (prefer this over assuming instant UI updates)."
+    )]
+    async fn wait(
+        &self,
+        Parameters(p): Parameters<WaitParams>,
+    ) -> Result<CallToolResult, McpError> {
+        tokio::time::sleep(std::time::Duration::from_millis(p.ms)).await;
+        Ok(text("waited"))
+    }
+
+    #[tool(description = "Composite and publish the preview frame at time t (seconds).")]
+    async fn seek(
+        &self,
+        Parameters(p): Parameters<SeekParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::Seek { t: p.t }).await?;
+        Ok(text("ok"))
+    }
+
+    #[tool(
+        description = "Get a summary of the current clip: {duration, zooms, cuts, speed_regions}."
+    )]
+    async fn clip_state(&self) -> Result<CallToolResult, McpError> {
+        match self.call(ControlRequest::ClipState).await? {
+            ControlResponse::Clip(c) => Ok(json(&c)),
+            other => Ok(text(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    #[tool(
+        description = "Sample the clip at the given times (seconds) and return PNG images so you can SEE the output and critique it (zoom centring, legibility, timing). Sample sparsely, e.g. around each zoom."
+    )]
+    async fn get_frames(
+        &self,
+        Parameters(p): Parameters<GetFramesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::GetFrames {
+                times: p.times,
+                width: p.width,
+            })
+            .await?
+        {
+            ControlResponse::Frames { frames } => {
+                let mut content = vec![Content::text(format!("{} frame(s)", frames.len()))];
+                for f in frames {
+                    content.push(Content::text(format!("t={:.3}s", f.t)));
+                    content.push(Content::image(f.png_base64, "image/png".to_string()));
+                }
+                Ok(CallToolResult::success(content))
+            }
+            other => Ok(text(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    #[tool(description = "Estimate the GIF export size in bytes for the given settings.")]
+    async fn estimate_gif(
+        &self,
+        Parameters(p): Parameters<EstimateParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .call(ControlRequest::EstimateGif {
+                fps: p.fps.unwrap_or(20),
+                width: p.width,
+                quality: p.quality.unwrap_or(80),
+            })
+            .await?
+        {
+            ControlResponse::Size { bytes } => Ok(text(bytes.to_string())),
+            other => Ok(text(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    #[tool(description = "Export the edited clip to an animated GIF at the given absolute path.")]
+    async fn export_gif(
+        &self,
+        Parameters(p): Parameters<ExportParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::ExportGif {
+            path: p.path.clone(),
+            fps: p.fps.unwrap_or(20),
+            width: p.width,
+            quality: p.quality.unwrap_or(80),
+        })
+        .await?;
+        Ok(text(format!("exported GIF to {}", p.path)))
+    }
+
+    #[tool(description = "Export the edited clip to an H.264 MP4 at the given absolute path.")]
+    async fn export_mp4(
+        &self,
+        Parameters(p): Parameters<ExportParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::ExportMp4 {
+            path: p.path.clone(),
+            fps: p.fps.unwrap_or(30),
+            width: p.width,
+            quality: p.quality.unwrap_or(80),
+        })
+        .await?;
+        Ok(text(format!("exported MP4 to {}", p.path)))
+    }
+}
+
+/// Guidance shown to the agent on connect.
+const INSTRUCTIONS: &str = "Vuoom AI Demo Director. Workflow: (1) screen_geometry, \
+    (2) set_region/set_zoom_amount, (3) start_recording, (4) drive the target app with \
+    click/type/key_chord/scroll (clicks also trigger cinematic auto-zoom) using wait between \
+    steps, (5) stop_recording, (6) get_frames to SEE the result and critique it, re-recording \
+    if needed, (7) export_gif/export_mp4. Vuoom must run with VUOOM_ENABLE_CONTROL=1.";
+
+#[tool_handler]
+impl ServerHandler for VuoomMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::from_build_env())
+            .with_instructions(INSTRUCTIONS.to_string())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let service = VuoomMcp::new().serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/vuoom-mcp/src/main.rs
+++ b/crates/vuoom-mcp/src/main.rs
@@ -135,6 +135,13 @@ struct ZoomParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct StartParams {
+    /// Seed a cinematic zoom on every click you inject (default true — the agent drives via
+    /// clicks). Set false for a static recording where you'll add zooms manually.
+    auto_zoom_on_click: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct PointParams {
     /// X in virtual-desktop physical px.
     x: i32,
@@ -274,9 +281,16 @@ impl VuoomMcp {
     }
 
     #[tool(
-        description = "Start recording the screen + global input. Auto-zoom is planned from the clicks you inject during the recording."
+        description = "Start recording the screen + global input. By default every click you inject seeds a cinematic auto-zoom; pass auto_zoom_on_click=false for a static recording."
     )]
-    async fn start_recording(&self) -> Result<CallToolResult, McpError> {
+    async fn start_recording(
+        &self,
+        Parameters(p): Parameters<StartParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call(ControlRequest::SetAutoZoomOnClick {
+            on: p.auto_zoom_on_click.unwrap_or(true),
+        })
+        .await?;
         self.call(ControlRequest::StartRecording).await?;
         Ok(text("recording started"))
     }

--- a/crates/vuoom-zoom/Cargo.toml
+++ b/crates/vuoom-zoom/Cargo.toml
@@ -12,3 +12,5 @@ serde.workspace = true
 
 [dev-dependencies]
 # property tests for the planner go here (no off-screen reveal, debounce, frequency limit)
+# serde_json backs the backward-compat (de)serialization tests for ZoomKeyframe / ZoomMode.
+serde_json.workspace = true

--- a/crates/vuoom-zoom/src/camera.rs
+++ b/crates/vuoom-zoom/src/camera.rs
@@ -301,13 +301,22 @@ mod tests {
     #[test]
     fn rect_span_fits_and_centers() {
         let cfg = ZoomConfig::default();
-        let r = NormRect { x: 0.5, y: 0.5, w: 0.3, h: 0.2 };
+        let r = NormRect {
+            x: 0.5,
+            y: 0.5,
+            w: 0.3,
+            h: 0.2,
+        };
         let track = simulate(&[], &[rect_kf(0.0, 5.0, 3.0, r)], 5.0, 60.0, &cfg);
         let s = track.at(4.5);
         let expected_zoom = r.fit_zoom(3.0);
         // The rect reduces the span amount (3.0) down to the fit zoom so it stays visible.
         assert!(expected_zoom < 3.0, "rect should have reduced the zoom");
-        assert!((s.zoom - expected_zoom).abs() < 0.05, "zoom {} != fit {expected_zoom}", s.zoom);
+        assert!(
+            (s.zoom - expected_zoom).abs() < 0.05,
+            "zoom {} != fit {expected_zoom}",
+            s.zoom
+        );
         let expected_center = clamp_camera(r.center(), expected_zoom);
         assert!(
             (s.center - expected_center).abs().max_element() < 0.02,
@@ -321,10 +330,19 @@ mod tests {
     fn rect_span_never_exceeds_amount() {
         let cfg = ZoomConfig::default();
         // A small rect could fit at a high zoom, but must not exceed the span amount.
-        let r = NormRect { x: 0.45, y: 0.45, w: 0.03, h: 0.03 };
+        let r = NormRect {
+            x: 0.45,
+            y: 0.45,
+            w: 0.03,
+            h: 0.03,
+        };
         let track = simulate(&[], &[rect_kf(0.0, 5.0, 1.8, r)], 5.0, 60.0, &cfg);
         for f in track.frames() {
-            assert!(f.zoom <= 1.8 + 1e-6, "rect zoom exceeded amount: {}", f.zoom);
+            assert!(
+                f.zoom <= 1.8 + 1e-6,
+                "rect zoom exceeded amount: {}",
+                f.zoom
+            );
         }
         assert!((track.at(4.5).zoom - 1.8).abs() < 0.05);
     }
@@ -332,11 +350,20 @@ mod tests {
     #[test]
     fn degenerate_rect_behaves_like_manual() {
         let cfg = ZoomConfig::default();
-        let r = NormRect { x: 0.3, y: 0.3, w: 0.0, h: 0.2 };
+        let r = NormRect {
+            x: 0.3,
+            y: 0.3,
+            w: 0.0,
+            h: 0.2,
+        };
         let track = simulate(&[], &[rect_kf(0.0, 5.0, 2.0, r)], 5.0, 60.0, &cfg);
         let s = track.at(4.5);
         // No area to fit -> holds the full span amount, centered on the (degenerate) center.
-        assert!((s.zoom - 2.0).abs() < 0.05, "degenerate rect changed zoom: {}", s.zoom);
+        assert!(
+            (s.zoom - 2.0).abs() < 0.05,
+            "degenerate rect changed zoom: {}",
+            s.zoom
+        );
         let expected_center = clamp_camera(r.center(), 2.0);
         assert!((s.center - expected_center).abs().max_element() < 0.02);
     }
@@ -346,8 +373,20 @@ mod tests {
     #[test]
     fn envelope_in_override_speeds_zoom_in() {
         let cfg = ZoomConfig::default();
-        let fast = simulate(&[], &[auto_kf(0.0, 3.0, 2.0, Some(0.05), None)], 3.0, 60.0, &cfg);
-        let slow = simulate(&[], &[auto_kf(0.0, 3.0, 2.0, Some(1.5), None)], 3.0, 60.0, &cfg);
+        let fast = simulate(
+            &[],
+            &[auto_kf(0.0, 3.0, 2.0, Some(0.05), None)],
+            3.0,
+            60.0,
+            &cfg,
+        );
+        let slow = simulate(
+            &[],
+            &[auto_kf(0.0, 3.0, 2.0, Some(1.5), None)],
+            3.0,
+            60.0,
+            &cfg,
+        );
         assert!(
             fast.at(0.3).zoom > slow.at(0.3).zoom + 0.2,
             "fast in-override not faster: {} vs {}",
@@ -374,8 +413,20 @@ mod tests {
     fn envelope_out_override_used_on_release() {
         let cfg = ZoomConfig::default();
         // Span ends at t=1; the release afterwards must honour the span's out override.
-        let fast_out = simulate(&[], &[auto_kf(0.0, 1.0, 2.0, None, Some(0.05))], 3.0, 60.0, &cfg);
-        let slow_out = simulate(&[], &[auto_kf(0.0, 1.0, 2.0, None, Some(1.5))], 3.0, 60.0, &cfg);
+        let fast_out = simulate(
+            &[],
+            &[auto_kf(0.0, 1.0, 2.0, None, Some(0.05))],
+            3.0,
+            60.0,
+            &cfg,
+        );
+        let slow_out = simulate(
+            &[],
+            &[auto_kf(0.0, 1.0, 2.0, None, Some(1.5))],
+            3.0,
+            60.0,
+            &cfg,
+        );
         assert!(
             fast_out.at(1.3).zoom < slow_out.at(1.3).zoom - 0.1,
             "fast out-override did not release faster: {} vs {}",
@@ -406,17 +457,34 @@ mod tests {
         let cfg = ZoomConfig::default();
         let kf = auto_kf(0.0, 5.0, 2.0, None, None);
         let with_pos = [
-            InputEvent::Move { t: 0.0, pos: DVec2::new(0.5, 0.5) },
-            InputEvent::KeyType { t: 0.5, pos: Some(DVec2::new(0.9, 0.5)) },
+            InputEvent::Move {
+                t: 0.0,
+                pos: DVec2::new(0.5, 0.5),
+            },
+            InputEvent::KeyType {
+                t: 0.5,
+                pos: Some(DVec2::new(0.9, 0.5)),
+            },
         ];
         let without = [
-            InputEvent::Move { t: 0.0, pos: DVec2::new(0.5, 0.5) },
+            InputEvent::Move {
+                t: 0.0,
+                pos: DVec2::new(0.5, 0.5),
+            },
             InputEvent::KeyType { t: 0.5, pos: None },
         ];
         let a = simulate(&with_pos, &[kf], 5.0, 60.0, &cfg).at(4.5);
         let b = simulate(&without, &[kf], 5.0, 60.0, &cfg).at(4.5);
-        assert!(a.center.x > 0.55, "caret-pos did not steer focus right: {}", a.center.x);
-        assert!((b.center.x - 0.5).abs() < 1e-6, "no-pos KeyType moved focus: {}", b.center.x);
+        assert!(
+            a.center.x > 0.55,
+            "caret-pos did not steer focus right: {}",
+            a.center.x
+        );
+        assert!(
+            (b.center.x - 0.5).abs() < 1e-6,
+            "no-pos KeyType moved focus: {}",
+            b.center.x
+        );
     }
 
     #[test]

--- a/crates/vuoom-zoom/src/camera.rs
+++ b/crates/vuoom-zoom/src/camera.rs
@@ -63,6 +63,12 @@ fn snap_to_edges(p: DVec2, ratio: f64) -> DVec2 {
     DVec2::new(snap_axis(p.x, ratio), snap_axis(p.y, ratio))
 }
 
+/// Clamp a per-span spring half-life override into the sane range the inspector uses for
+/// style half-lives (0.05–1.5 s), leaving `None` untouched so the caller can fall back.
+fn clamp_hl(hl: Option<f64>) -> Option<f64> {
+    hl.map(|h| h.clamp(0.05, 1.5))
+}
+
 fn snap_axis(v: f64, ratio: f64) -> f64 {
     if ratio <= 0.0 {
         v
@@ -151,6 +157,9 @@ pub fn simulate(
     let mut pan_target = DVec2::splat(0.5);
     let mut zoom = 1.0_f64;
     let mut zoom_v = 0.0_f64;
+    // Zoom-out half-life carried over from the most-recently-active span, so a release that
+    // happens *after* a span ends still honours that span's `hl_zoom_out` override.
+    let mut release_hl = cfg.hl_zoom * 0.85;
 
     let mut si = 0;
     let mut frames = Vec::with_capacity(frame_count);
@@ -173,13 +182,14 @@ pub fn simulate(
 
         let active = keyframes.iter().find(|k| k.contains(t));
         let (target_zoom, focus) = match active {
-            Some(k) => {
-                let f = match k.mode {
-                    ZoomMode::Auto => snap_to_edges(smoothed, k.edge_snap_ratio),
-                    ZoomMode::Manual { pos } => pos,
-                };
-                (k.amount, f)
-            }
+            Some(k) => match k.mode {
+                ZoomMode::Auto => (k.amount, snap_to_edges(smoothed, k.edge_snap_ratio)),
+                ZoomMode::Manual { pos } => (k.amount, pos),
+                // Fit-and-center on the rect: focus at its center; the zoom may only be
+                // *reduced* (never raised) so the whole subject fits. The off-screen
+                // clamp keeps the center on-frame, so no extra edge-snap is applied here.
+                ZoomMode::Rect { rect } => (rect.fit_zoom(k.amount), rect.center()),
+            },
             None => (1.0, DVec2::splat(0.5)),
         };
 
@@ -189,11 +199,16 @@ pub fn simulate(
             pan_target = focus;
         }
 
-        // Zoom-out a touch faster than zoom-in (matches the documented feel).
-        let zoom_hl = if target_zoom < zoom {
-            cfg.hl_zoom * 0.85
-        } else {
-            cfg.hl_zoom
+        // Zoom spring half-life. While a span is active, use its zoom-in override (or the
+        // config default); while releasing between/after spans, use the most-recently-active
+        // span's zoom-out override (or the documented `hl_zoom * 0.85` faster release).
+        let default_release_hl = cfg.hl_zoom * 0.85;
+        let zoom_hl = match active {
+            Some(k) => {
+                release_hl = clamp_hl(k.hl_zoom_out).unwrap_or(default_release_hl);
+                clamp_hl(k.hl_zoom_in).unwrap_or(cfg.hl_zoom)
+            }
+            None => release_hl,
         };
         spring_update(&mut zoom, &mut zoom_v, target_zoom, zoom_hl, dt);
         spring_vec(&mut center, &mut center_v, pan_target, cfg.hl_pan, dt);
@@ -246,6 +261,162 @@ mod tests {
         let (mut x, mut v) = (0.0, 0.0);
         spring_update(&mut x, &mut v, 1.0, 0.0, 1.0 / 60.0);
         assert!(x.is_finite() && v.is_finite(), "x={x} v={v}");
+    }
+
+    use crate::event::InputEvent;
+    use crate::keyframe::NormRect;
+
+    fn auto_kf(
+        start: f64,
+        end: f64,
+        amount: f64,
+        hl_in: Option<f64>,
+        hl_out: Option<f64>,
+    ) -> ZoomKeyframe {
+        ZoomKeyframe {
+            start,
+            end,
+            amount,
+            mode: ZoomMode::Auto,
+            edge_snap_ratio: 0.0,
+            hl_zoom_in: hl_in,
+            hl_zoom_out: hl_out,
+        }
+    }
+
+    fn rect_kf(start: f64, end: f64, amount: f64, rect: NormRect) -> ZoomKeyframe {
+        ZoomKeyframe {
+            start,
+            end,
+            amount,
+            mode: ZoomMode::Rect { rect },
+            edge_snap_ratio: 0.0,
+            hl_zoom_in: None,
+            hl_zoom_out: None,
+        }
+    }
+
+    // ---- Feature 1: rect focus ----
+
+    #[test]
+    fn rect_span_fits_and_centers() {
+        let cfg = ZoomConfig::default();
+        let r = NormRect { x: 0.5, y: 0.5, w: 0.3, h: 0.2 };
+        let track = simulate(&[], &[rect_kf(0.0, 5.0, 3.0, r)], 5.0, 60.0, &cfg);
+        let s = track.at(4.5);
+        let expected_zoom = r.fit_zoom(3.0);
+        // The rect reduces the span amount (3.0) down to the fit zoom so it stays visible.
+        assert!(expected_zoom < 3.0, "rect should have reduced the zoom");
+        assert!((s.zoom - expected_zoom).abs() < 0.05, "zoom {} != fit {expected_zoom}", s.zoom);
+        let expected_center = clamp_camera(r.center(), expected_zoom);
+        assert!(
+            (s.center - expected_center).abs().max_element() < 0.02,
+            "center {:?} not at rect center {:?}",
+            s.center,
+            expected_center
+        );
+    }
+
+    #[test]
+    fn rect_span_never_exceeds_amount() {
+        let cfg = ZoomConfig::default();
+        // A small rect could fit at a high zoom, but must not exceed the span amount.
+        let r = NormRect { x: 0.45, y: 0.45, w: 0.03, h: 0.03 };
+        let track = simulate(&[], &[rect_kf(0.0, 5.0, 1.8, r)], 5.0, 60.0, &cfg);
+        for f in track.frames() {
+            assert!(f.zoom <= 1.8 + 1e-6, "rect zoom exceeded amount: {}", f.zoom);
+        }
+        assert!((track.at(4.5).zoom - 1.8).abs() < 0.05);
+    }
+
+    #[test]
+    fn degenerate_rect_behaves_like_manual() {
+        let cfg = ZoomConfig::default();
+        let r = NormRect { x: 0.3, y: 0.3, w: 0.0, h: 0.2 };
+        let track = simulate(&[], &[rect_kf(0.0, 5.0, 2.0, r)], 5.0, 60.0, &cfg);
+        let s = track.at(4.5);
+        // No area to fit -> holds the full span amount, centered on the (degenerate) center.
+        assert!((s.zoom - 2.0).abs() < 0.05, "degenerate rect changed zoom: {}", s.zoom);
+        let expected_center = clamp_camera(r.center(), 2.0);
+        assert!((s.center - expected_center).abs().max_element() < 0.02);
+    }
+
+    // ---- Feature 2: per-span envelope overrides ----
+
+    #[test]
+    fn envelope_in_override_speeds_zoom_in() {
+        let cfg = ZoomConfig::default();
+        let fast = simulate(&[], &[auto_kf(0.0, 3.0, 2.0, Some(0.05), None)], 3.0, 60.0, &cfg);
+        let slow = simulate(&[], &[auto_kf(0.0, 3.0, 2.0, Some(1.5), None)], 3.0, 60.0, &cfg);
+        assert!(
+            fast.at(0.3).zoom > slow.at(0.3).zoom + 0.2,
+            "fast in-override not faster: {} vs {}",
+            fast.at(0.3).zoom,
+            slow.at(0.3).zoom
+        );
+    }
+
+    #[test]
+    fn envelope_in_none_falls_back_to_config() {
+        let cfg = ZoomConfig::default();
+        let default_kf = simulate(&[], &[auto_kf(0.0, 3.0, 2.0, None, None)], 3.0, 60.0, &cfg);
+        let explicit = simulate(
+            &[],
+            &[auto_kf(0.0, 3.0, 2.0, Some(cfg.hl_zoom), None)],
+            3.0,
+            60.0,
+            &cfg,
+        );
+        assert_eq!(default_kf.frames(), explicit.frames());
+    }
+
+    #[test]
+    fn envelope_out_override_used_on_release() {
+        let cfg = ZoomConfig::default();
+        // Span ends at t=1; the release afterwards must honour the span's out override.
+        let fast_out = simulate(&[], &[auto_kf(0.0, 1.0, 2.0, None, Some(0.05))], 3.0, 60.0, &cfg);
+        let slow_out = simulate(&[], &[auto_kf(0.0, 1.0, 2.0, None, Some(1.5))], 3.0, 60.0, &cfg);
+        assert!(
+            fast_out.at(1.3).zoom < slow_out.at(1.3).zoom - 0.1,
+            "fast out-override did not release faster: {} vs {}",
+            fast_out.at(1.3).zoom,
+            slow_out.at(1.3).zoom
+        );
+    }
+
+    #[test]
+    fn envelope_out_none_falls_back_to_faster_release() {
+        let cfg = ZoomConfig::default();
+        // None out-override reproduces the documented `hl_zoom * 0.85` faster release.
+        let default_kf = simulate(&[], &[auto_kf(0.0, 1.0, 2.0, None, None)], 3.0, 60.0, &cfg);
+        let explicit = simulate(
+            &[],
+            &[auto_kf(0.0, 1.0, 2.0, None, Some(cfg.hl_zoom * 0.85))],
+            3.0,
+            60.0,
+            &cfg,
+        );
+        assert_eq!(default_kf.frames(), explicit.frames());
+    }
+
+    // ---- Feature 3: caret-follow ----
+
+    #[test]
+    fn keytype_with_pos_steers_auto_focus() {
+        let cfg = ZoomConfig::default();
+        let kf = auto_kf(0.0, 5.0, 2.0, None, None);
+        let with_pos = [
+            InputEvent::Move { t: 0.0, pos: DVec2::new(0.5, 0.5) },
+            InputEvent::KeyType { t: 0.5, pos: Some(DVec2::new(0.9, 0.5)) },
+        ];
+        let without = [
+            InputEvent::Move { t: 0.0, pos: DVec2::new(0.5, 0.5) },
+            InputEvent::KeyType { t: 0.5, pos: None },
+        ];
+        let a = simulate(&with_pos, &[kf], 5.0, 60.0, &cfg).at(4.5);
+        let b = simulate(&without, &[kf], 5.0, 60.0, &cfg).at(4.5);
+        assert!(a.center.x > 0.55, "caret-pos did not steer focus right: {}", a.center.x);
+        assert!((b.center.x - 0.5).abs() < 1e-6, "no-pos KeyType moved focus: {}", b.center.x);
     }
 
     #[test]

--- a/crates/vuoom-zoom/src/edit.rs
+++ b/crates/vuoom-zoom/src/edit.rs
@@ -78,6 +78,8 @@ mod tests {
             amount: 1.8,
             mode: ZoomMode::Auto,
             edge_snap_ratio: 0.25,
+            hl_zoom_in: None,
+            hl_zoom_out: None,
         }
     }
 

--- a/crates/vuoom-zoom/src/event.rs
+++ b/crates/vuoom-zoom/src/event.rs
@@ -33,8 +33,15 @@ pub enum InputEvent {
     DragStart { t: f64, pos: DVec2 },
     /// A drag ended at `pos`.
     DragEnd { t: f64, pos: DVec2 },
-    /// A key was typed (no position; used to sustain a zoom while typing).
-    KeyType { t: f64 },
+    /// A key was typed. Sustains a zoom while typing. An optional `pos` (the caret /
+    /// last-injection point, normalized) lets typing *steer* an `Auto` span toward the
+    /// caret so text does not run off the edge; `None` behaves exactly as before (sustain
+    /// only, no focus change). Absent in older saved projects (`serde` default).
+    KeyType {
+        t: f64,
+        #[serde(default)]
+        pos: Option<DVec2>,
+    },
     /// The user deliberately requested a zoom at `pos` (e.g. the manual zoom hotkey).
     /// Always a zoom trigger, regardless of the click-to-zoom setting.
     ZoomMark { t: f64, pos: DVec2 },
@@ -51,11 +58,14 @@ impl InputEvent {
             | InputEvent::DragStart { t, .. }
             | InputEvent::DragEnd { t, .. }
             | InputEvent::ZoomMark { t, .. }
-            | InputEvent::KeyType { t } => t,
+            | InputEvent::KeyType { t, .. } => t,
         }
     }
 
-    /// The event's normalized position, if it has one (`KeyType` does not).
+    /// The event's normalized position, if it has one.
+    ///
+    /// `KeyType` carries a position only when a caret point was captured; a plain typed
+    /// key (`pos: None`) still returns `None`, so it sustains a hold without moving focus.
     #[must_use]
     pub fn pos(&self) -> Option<DVec2> {
         match *self {
@@ -65,7 +75,7 @@ impl InputEvent {
             | InputEvent::DragStart { pos, .. }
             | InputEvent::ZoomMark { pos, .. }
             | InputEvent::DragEnd { pos, .. } => Some(pos),
-            InputEvent::KeyType { .. } => None,
+            InputEvent::KeyType { pos, .. } => pos,
         }
     }
 

--- a/crates/vuoom-zoom/src/keyframe.rs
+++ b/crates/vuoom-zoom/src/keyframe.rs
@@ -180,15 +180,24 @@ mod tests {
         // Externally-tagged Manual variant from an old project file.
         let old = r#"{"Manual":{"pos":[0.4,0.6]}}"#;
         let mode: ZoomMode = serde_json::from_str(old).unwrap();
-        assert_eq!(mode, ZoomMode::Manual { pos: DVec2::new(0.4, 0.6) });
+        assert_eq!(
+            mode,
+            ZoomMode::Manual {
+                pos: DVec2::new(0.4, 0.6)
+            }
+        );
     }
 
     #[test]
     fn zoom_mode_round_trips_including_rect() {
         for mode in [
             ZoomMode::Auto,
-            ZoomMode::Manual { pos: DVec2::new(0.1, 0.9) },
-            ZoomMode::Rect { rect: rect(0.1, 0.2, 0.3, 0.4) },
+            ZoomMode::Manual {
+                pos: DVec2::new(0.1, 0.9),
+            },
+            ZoomMode::Rect {
+                rect: rect(0.1, 0.2, 0.3, 0.4),
+            },
         ] {
             let json = serde_json::to_string(&mode).unwrap();
             let back: ZoomMode = serde_json::from_str(&json).unwrap();
@@ -202,7 +211,9 @@ mod tests {
             start: 0.5,
             end: 2.5,
             amount: 2.0,
-            mode: ZoomMode::Rect { rect: rect(0.2, 0.2, 0.5, 0.4) },
+            mode: ZoomMode::Rect {
+                rect: rect(0.2, 0.2, 0.5, 0.4),
+            },
             edge_snap_ratio: 0.25,
             hl_zoom_in: Some(0.4),
             hl_zoom_out: Some(0.2),

--- a/crates/vuoom-zoom/src/keyframe.rs
+++ b/crates/vuoom-zoom/src/keyframe.rs
@@ -7,6 +7,52 @@
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 
+/// Padding factor applied when fitting a [`ZoomMode::Rect`] subject to the viewport:
+/// the rect's larger side is inflated by this much before choosing the fit zoom, so the
+/// subject never touches the crop edge (~12% breathing room).
+pub const RECT_FIT_PADDING: f64 = 1.12;
+
+/// A normalized rectangle in `0.0..=1.0` capture space (`x`,`y` = top-left corner).
+///
+/// Defined here (not imported from `vuoom-render`) because `vuoom-render` depends on
+/// `vuoom-zoom`, so the dependency may only point one way.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct NormRect {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+impl NormRect {
+    /// The rect's center point in normalized space.
+    #[must_use]
+    pub fn center(&self) -> DVec2 {
+        DVec2::new(self.x + self.w * 0.5, self.y + self.h * 0.5)
+    }
+
+    /// A rect with a non-positive side has no area to fit — callers fall back to a plain
+    /// point focus at [`Self::center`].
+    #[must_use]
+    pub fn is_degenerate(&self) -> bool {
+        self.w <= 0.0 || self.h <= 0.0
+    }
+
+    /// The zoom multiplier that fits this rect inside the (square) viewport with
+    /// [`RECT_FIT_PADDING`] breathing room, **never exceeding** `amount` and never below
+    /// `1.0`: the rect may only *reduce* the span zoom so the whole subject stays visible.
+    ///
+    /// A degenerate rect returns `amount` unchanged (behave like a fixed point focus).
+    #[must_use]
+    pub fn fit_zoom(&self, amount: f64) -> f64 {
+        if self.is_degenerate() {
+            return amount;
+        }
+        let fit = 1.0 / (self.w.max(self.h) * RECT_FIT_PADDING);
+        amount.min(fit).clamp(1.0, amount)
+    }
+}
+
 /// How a zoom segment chooses its focus point.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum ZoomMode {
@@ -14,6 +60,9 @@ pub enum ZoomMode {
     Auto,
     /// Hold a fixed normalized focus point.
     Manual { pos: DVec2 },
+    /// Fit and center on a normalized rectangle: focus at the rect center, with the zoom
+    /// reduced (if needed) so the whole rect fits with padding. See [`NormRect::fit_zoom`].
+    Rect { rect: NormRect },
 }
 
 /// One zoom segment on the timeline.
@@ -29,6 +78,16 @@ pub struct ZoomKeyframe {
     pub mode: ZoomMode,
     /// Edge-snap strength for this segment (copied from config at plan time, editable).
     pub edge_snap_ratio: f64,
+    /// Optional per-span override for the zoom-*in* spring half-life (seconds), same units
+    /// as [`crate::ZoomConfig::hl_zoom`]. `None` falls back to the config default. Clamped
+    /// to a sane range by the camera. Absent in older saved projects (`serde` default).
+    #[serde(default)]
+    pub hl_zoom_in: Option<f64>,
+    /// Optional per-span override for the zoom-*out* (release) spring half-life (seconds).
+    /// `None` falls back to the current release behaviour (`hl_zoom * 0.85`). Clamped to a
+    /// sane range by the camera. Absent in older saved projects (`serde` default).
+    #[serde(default)]
+    pub hl_zoom_out: Option<f64>,
 }
 
 impl ZoomKeyframe {
@@ -42,5 +101,114 @@ impl ZoomKeyframe {
     #[must_use]
     pub fn duration(&self) -> f64 {
         (self.end - self.start).max(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: f64, y: f64, w: f64, h: f64) -> NormRect {
+        NormRect { x, y, w, h }
+    }
+
+    #[test]
+    fn rect_center_is_the_midpoint() {
+        assert_eq!(rect(0.2, 0.4, 0.4, 0.2).center(), DVec2::new(0.4, 0.5));
+    }
+
+    #[test]
+    fn fit_zoom_fits_the_rect_with_padding() {
+        // A 0.4-wide rect: fit = 1 / (0.4 * 1.12) ≈ 2.232. With a generous span amount the
+        // effective zoom is the fit value, so the padded rect exactly fills the viewport.
+        let r = rect(0.3, 0.3, 0.4, 0.3);
+        let z = r.fit_zoom(10.0);
+        let expected = 1.0 / (0.4 * RECT_FIT_PADDING);
+        assert!((z - expected).abs() < 1e-12, "fit zoom {z} != {expected}");
+        // The viewport side (1/z) must exceed the rect's larger side by the padding factor.
+        let viewport_side = 1.0 / z;
+        assert!(
+            viewport_side >= 0.4 * RECT_FIT_PADDING - 1e-12,
+            "rect does not fit inside viewport: side {viewport_side}"
+        );
+    }
+
+    #[test]
+    fn fit_zoom_never_exceeds_span_amount() {
+        // A tiny rect *could* fit at a huge zoom, but the span amount caps it.
+        let r = rect(0.45, 0.45, 0.02, 0.02);
+        let amount = 1.8;
+        assert!(
+            r.fit_zoom(amount) <= amount + 1e-12,
+            "fit zoom exceeded span amount"
+        );
+        assert!((r.fit_zoom(amount) - amount).abs() < 1e-12);
+    }
+
+    #[test]
+    fn fit_zoom_only_reduces_never_below_one() {
+        // A rect nearly filling the frame forces the zoom down to 1.0 (whole frame).
+        let r = rect(0.02, 0.02, 0.96, 0.96);
+        assert!((r.fit_zoom(1.8) - 1.0).abs() < 1e-12, "should clamp to 1.0");
+    }
+
+    #[test]
+    fn degenerate_rect_returns_amount_unchanged() {
+        assert!(rect(0.4, 0.4, 0.0, 0.3).is_degenerate());
+        assert!(rect(0.4, 0.4, 0.3, -0.1).is_degenerate());
+        assert_eq!(rect(0.4, 0.4, 0.0, 0.3).fit_zoom(2.5), 2.5);
+    }
+
+    #[test]
+    fn old_keyframe_json_without_new_fields_deserializes() {
+        // A project saved before the envelope + rect fields existed.
+        let old = r#"{
+            "start": 1.0,
+            "end": 3.0,
+            "amount": 1.8,
+            "mode": "Auto",
+            "edge_snap_ratio": 0.25
+        }"#;
+        let kf: ZoomKeyframe = serde_json::from_str(old).unwrap();
+        assert_eq!(kf.mode, ZoomMode::Auto);
+        assert_eq!(kf.hl_zoom_in, None);
+        assert_eq!(kf.hl_zoom_out, None);
+    }
+
+    #[test]
+    fn old_manual_mode_json_still_deserializes() {
+        // Externally-tagged Manual variant from an old project file.
+        let old = r#"{"Manual":{"pos":[0.4,0.6]}}"#;
+        let mode: ZoomMode = serde_json::from_str(old).unwrap();
+        assert_eq!(mode, ZoomMode::Manual { pos: DVec2::new(0.4, 0.6) });
+    }
+
+    #[test]
+    fn zoom_mode_round_trips_including_rect() {
+        for mode in [
+            ZoomMode::Auto,
+            ZoomMode::Manual { pos: DVec2::new(0.1, 0.9) },
+            ZoomMode::Rect { rect: rect(0.1, 0.2, 0.3, 0.4) },
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let back: ZoomMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(mode, back, "round-trip changed the mode: {json}");
+        }
+    }
+
+    #[test]
+    fn keyframe_with_overrides_round_trips() {
+        let kf = ZoomKeyframe {
+            start: 0.5,
+            end: 2.5,
+            amount: 2.0,
+            mode: ZoomMode::Rect { rect: rect(0.2, 0.2, 0.5, 0.4) },
+            edge_snap_ratio: 0.25,
+            hl_zoom_in: Some(0.4),
+            hl_zoom_out: Some(0.2),
+        };
+        let json = serde_json::to_string(&kf).unwrap();
+        let back: ZoomKeyframe = serde_json::from_str(&json).unwrap();
+        assert_eq!(kf, back);
     }
 }

--- a/crates/vuoom-zoom/src/lib.rs
+++ b/crates/vuoom-zoom/src/lib.rs
@@ -17,7 +17,7 @@ pub use camera::{clamp_camera, simulate, spring_update, CameraState, CameraTrack
 pub use config::ZoomConfig;
 pub use edit::{insert_sorted, move_to, remove, resize, sort_by_start, MIN_LEN};
 pub use event::{InputEvent, MouseButton};
-pub use keyframe::{ZoomKeyframe, ZoomMode};
+pub use keyframe::{NormRect, ZoomKeyframe, ZoomMode, RECT_FIT_PADDING};
 pub use planner::plan_zooms;
 
 /// Convenience: plan zoom segments and simulate the camera in one call.

--- a/crates/vuoom-zoom/src/planner.rs
+++ b/crates/vuoom-zoom/src/planner.rs
@@ -71,6 +71,8 @@ fn manual_toggle_segments(
                 amount: cfg.amount,
                 mode: ZoomMode::Auto,
                 edge_snap_ratio: cfg.edge_snap_ratio,
+                hl_zoom_in: None,
+                hl_zoom_out: None,
             });
         }
         i += 2; // skip the matching zoom-out press
@@ -145,6 +147,8 @@ fn click_segments(events: &[InputEvent], duration: f64, cfg: &ZoomConfig) -> Vec
                 amount: cfg.amount,
                 mode: ZoomMode::Auto,
                 edge_snap_ratio: cfg.edge_snap_ratio,
+                hl_zoom_in: None,
+                hl_zoom_out: None,
             });
         }
     }
@@ -263,6 +267,18 @@ mod tests {
         let cfg = ZoomConfig::default();
         assert!(!cfg.auto_zoom_on_click);
         let events = [click(1.0, 0.3, 0.3), click(5.0, 0.7, 0.7)];
+        assert!(plan_zooms(&events, 8.0, &cfg).is_empty());
+    }
+
+    #[test]
+    fn positioned_keytype_does_not_spawn_a_zoom() {
+        // A caret-positioned KeyType is steer/extend only — it must never seed a cluster,
+        // even with click-to-zoom enabled (only clicks/drags/zoom-marks spawn).
+        let cfg = click_cfg();
+        let events = [
+            InputEvent::KeyType { t: 1.0, pos: Some(DVec2::new(0.4, 0.4)) },
+            InputEvent::KeyType { t: 1.5, pos: Some(DVec2::new(0.42, 0.41)) },
+        ];
         assert!(plan_zooms(&events, 8.0, &cfg).is_empty());
     }
 

--- a/crates/vuoom-zoom/src/planner.rs
+++ b/crates/vuoom-zoom/src/planner.rs
@@ -276,8 +276,14 @@ mod tests {
         // even with click-to-zoom enabled (only clicks/drags/zoom-marks spawn).
         let cfg = click_cfg();
         let events = [
-            InputEvent::KeyType { t: 1.0, pos: Some(DVec2::new(0.4, 0.4)) },
-            InputEvent::KeyType { t: 1.5, pos: Some(DVec2::new(0.42, 0.41)) },
+            InputEvent::KeyType {
+                t: 1.0,
+                pos: Some(DVec2::new(0.4, 0.4)),
+            },
+            InputEvent::KeyType {
+                t: 1.5,
+                pos: Some(DVec2::new(0.42, 0.41)),
+            },
         ];
         assert!(plan_zooms(&events, 8.0, &cfg).is_empty());
     }

--- a/docs/13-AI-Demo-Director-Research.md
+++ b/docs/13-AI-Demo-Director-Research.md
@@ -1,0 +1,181 @@
+# 13 — AI Demo Director (MCP) — Research & Plan
+
+**Status:** Research complete (2026-06-14). Decision gate — not yet approved for build.
+**Branch:** `feat/ai-demo-director-mcp`
+
+---
+
+## The idea
+
+Add an **MCP server** to Vuoom so an AI agent (Claude) can:
+
+1. **Drive** Vuoom to record a demo — set region, start recording, drive a *target app*
+   (click buttons, type), trigger cinematic auto-zooms, stop, export GIF/MP4.
+2. **Watch** the result — sample frames from the output and inspect them with vision.
+3. **Critique & re-record** — judge the demo against a rubric and iterate to improve it.
+4. Output a polished demo GIF/video from a plain-English request.
+
+One-line pitch: *"An AI director that makes Windows screen-demo GIFs for you — and
+self-improves by watching its own output."*
+
+---
+
+## Novelty verdict
+
+**Not novel as a bag of features. Genuinely novel as a specific recombination.**
+
+Every individual piece already ships somewhere (mid-2026):
+
+| Piece | Already exists as |
+|---|---|
+| Cinematic auto-zoom recorder | Screen Studio (Mac), Cap, FocuSee, Open Screen |
+| Open-source Tauri/Rust recorder | **Cap** (our stack-twin) |
+| Agent-driven recording via MCP | **Open Screen** (Mac), **DemoSmith** (browser) |
+| Screen-recording + GIF/MP4 export MCP | pagecast, mcp-video, DevStudio, video-recorder-mcp |
+| Cinematic auto-zoom *inside* an MCP recorder | **pagecast** (browser-only) |
+| Tauri control plane via MCP | tauri-plugin-mcp-bridge + 4 siblings |
+| Vision self-critique on captures | screen-view-mcp (stills); ReLook / Amazon papers (UI loops) |
+
+**What exists nowhere — our only defensible moat:**
+> A **native Windows**, **free/open** cinematic auto-zoom recorder that an agent drives via
+> MCP, that then **watches its own GIF/MP4 with vision, critiques it, and re-records to
+> improve** — a record → watch → critique → re-record loop.
+
+Every shipping agent-driven recorder today is **one-pass** (the MCP is a one-way trigger).
+No one combines native-desktop capture + cinematic auto-zoom + a vision self-improvement
+loop, and no open-source auto-zoom+MCP recorder exists for **Windows** at all.
+
+**The 3 closest competitors:**
+1. **Open Screen (openscreen.io)** — open, auto-zoom, built-in MCP, agent-driven. *Beats us
+   on maturity; we beat it on Windows + the self-critique loop (it's Mac-only, one-pass).*
+2. **mcpware/pagecast** — MIT MCP, cinematic auto-zoom + control + GIF/MP4. *We beat it on
+   native desktop (it's browser-only) + the critique loop.*
+3. **Cap (cap.so)** — open Tauri/Rust, Win+Mac, auto-zoom, CLI. *The "isn't this just Cap?"
+   risk; best-resourced rival that could add MCP fastest. We beat it on MCP + AI loop today.*
+
+**Differentiation strategy:** lead with the **self-improving vision loop**, not the auto-zoom
+(commodity). Own **native Windows + free**. Be honest about target-app driving (reliable for
+web, harder for arbitrary desktop).
+
+---
+
+## Technical feasibility (verified against our code)
+
+**~85% of "drive Vuoom to record + export programmatically" already exists and is cleanly
+callable.** The engine is pure and modular; the Tauri command surface is already a thin
+JSON-RPC layer over it.
+
+### Already there (no/low work)
+- Full command surface in `src-tauri/src/commands.rs`: `set_region`, `set_zoom_amount`,
+  `start_recording`, `finish_recording`, `export_gif`, `export_mp4`, `estimate_gif`,
+  plus all timeline/zoom/annotation CRUD.
+- Recording pipeline is pure: `Session::start_recording()` → `stop_recording()` →
+  `RecordingSummary` (`src-tauri/src/session.rs`).
+- **Auto-zoom planning is purely algorithmic and deterministic** (`vuoom-zoom`, verified
+  `simulation_is_deterministic()` test): same input log → same camera track.
+- `.vuoom` project is fully serializable JSON incl. the persisted input event log
+  (`vuoom-project`), so synthetic events can be generated, injected, re-planned, re-rendered.
+- Export is **fully headless** — no UI dependency (GIF + MP4).
+- Localhost WebSocket preview server already exists (`vuoom-preview`) — the IPC plumbing
+  pattern for a control channel is already in-repo. gifski already runs as a sidecar.
+
+### The free win (verified in code)
+Vuoom captures input via `SetWindowsHookEx(WH_MOUSE_LL/WH_KEYBOARD_LL)` with **zero
+injected-input filtering** (`crates/vuoom-input/src/recorder.rs` — no `LLMHF_INJECTED`
+checks). So **synthetic clicks from `SendInput` flow through the existing hook and trigger
+auto-zoom exactly like real clicks, no code change.** One mechanism (SendInput on the target
+window) both drives the app *and* produces the click log that drives the zooms. Elegant.
+
+### The hard parts (honest)
+| Component | Difficulty | Why |
+|---|---|---|
+| MCP server (rmcp sidecar + IPC) | 3/10 | Official Rust SDK `rmcp`; infra pattern already in repo |
+| Synthetic input → auto-zoom | 2/10 | **Works as-is**; hooks see injected input, deterministic planner |
+| Browser target driving (Playwright/CDP) | 4/10 | Mature; a11y refs + auto-wait kill most flakiness |
+| **Desktop target driving (any app)** | **8/10** | UIA coverage gaps; coordinates brittle (DPI/multi-mon); no universal method |
+| **Reliability / sync / determinism** | **8/10** | Real-app non-determinism is irreducible; races compound |
+| Verify loop (vision) | 5/10 | Easy to build, hard to make converge + cost-controlled |
+| Security / sandboxing | 6/10 | Known controls; airtight containment is unsolved |
+
+**The single hardest problem:** robustly driving an *arbitrary desktop* target and
+synchronizing actions with capture. **If we constrain the MVP target to a browser, this
+largely dissolves** (CDP/Playwright accessibility refs + built-in auto-wait).
+
+### Vision verify-loop reality check
+- Claude vision sees a **GIF as its first frame only** → we must sample frames ourselves
+  (cheaply, from the pre-encode RGBA buffer at known zoom timestamps — ~6–10 frames).
+- The three judgments we most need — **zoom centering (spatial), text legibility (OCR on
+  compressed frames), timing (temporal)** — are exactly where vision LLMs are *least*
+  reliable. So the loop must use **pairwise comparison ("is take A or B better?") + a
+  multi-dimensional rubric**, NOT absolute 1–10 scoring (per MLLM-as-a-judge evidence).
+- Loops plateau fast (~+18% over 1–3 cycles). **Hard cap at 3–4 iterations.** Each cycle is
+  tens of seconds + ~25–30k vision tokens — dollars, not cents.
+
+---
+
+## Recommended MVP architecture (browser-target first)
+
+1. **Sidecar MCP server** — separate Rust binary using `rmcp`, **stdio** transport, launched
+   by the MCP client. Pin the rmcp version (pre-2.0, churns).
+2. **Loopback IPC** (WebSocket/HTTP on `127.0.0.1`) sidecar → running Vuoom, reusing the
+   existing preview-server plumbing. IPC commands map 1:1 to existing Tauri commands.
+3. **Target = a browser**, driven by **Playwright/CDP** (stable a11y refs + auto-waiting).
+   Defer arbitrary-desktop driving (UIA-first + coordinate fallback) to v2.
+4. **Zooms via real `SendInput` clicks** on the target window — flow through the existing
+   hook unchanged. Convert target coords → SendInput-normalized space using the window's DPI.
+5. **Sync, don't sleep:** gate the first action on a confirmed first-capture-frame; gate each
+   step on Playwright actionability.
+6. **Verify loop:** sample 6–10 frames from the pre-encode buffer at zoom timestamps → judge
+   against a fixed rubric (pairwise where possible) → **hard cap 3–4 iterations**.
+7. **Safety:** run scoped to the target window; reject clicks outside its bounds; panic-abort
+   hotkey; least privilege; treat on-screen content as untrusted (prompt-injection risk).
+
+### Phasing
+- **Phase 0 — Headless shim (1–2 days).** Decouple region selection + stop from the overlay
+  UI so recording can be driven entirely via IPC params. (~15% gap identified.)
+- **Phase 1 — MCP control plane (2–4 days).** rmcp sidecar + loopback IPC; tools: `set_region`,
+  `start_recording`, `stop_recording`, `export_gif`, `export_mp4`, `get_state`, `get_frames`.
+  Outcome: an agent can record + export Vuoom with no GUI clicks.
+- **Phase 2 — Browser target driving (3–5 days).** Playwright/CDP driver; click/type by
+  selector; SendInput on the browser window so zooms fire. Sync on actionability + first frame.
+  Outcome: "make a demo of this web page" → a cinematic GIF, one-pass.
+- **Phase 3 — Vision verify loop (3–5 days).** Frame sampling + rubric judge + bounded retry.
+  Outcome: the self-improving loop — the actual moat.
+- **v2 (later) — arbitrary desktop targets** (UIA-first + vision fallback). The hard 8/10 tail.
+
+---
+
+## Verdict
+
+- **Novelty:** Real but narrow. The moat is the **self-critique loop + native-Windows-free**,
+  not auto-zoom. Worth building *if* we lead with the loop.
+- **Feasibility:** The Vuoom side is the easy 85%. The risk lives entirely in (a) driving the
+  target app and (b) sync/determinism — both **cut off by scoping the MVP to a browser**.
+- **Effort (MVP, browser-scoped):** ~**2–3 focused weeks** across Phases 0–3.
+- **Confidence:**
+  - Phases 0–2 (agent records + exports + drives a browser): **~85%** — well-supported, mostly
+    plumbing over existing, deterministic engine code.
+  - Phase 3 (the vision loop *measurably* improves demos): **~55%** — the capability is real
+    but rests on the least-reliable vision-LLM skills; mitigated by pairwise+rubric+caps, but
+    this is the part that could underwhelm.
+  - "AI drives *any* Windows desktop app" (v2): **~35%** — genuinely hard; out of MVP scope.
+
+**Recommendation:** Build the **browser-scoped MVP (Phases 0–3)**. It delivers the full
+"AI generates and self-critiques a demo GIF" story with the unreliable tail cut off, and it's
+the differentiated story no competitor has on Windows.
+
+---
+
+## Sources
+Open Screen <https://openscreen.io/> · DemoSmith MCP
+<https://github.com/G0d2i11a/demosmith-mcp> · pagecast <https://github.com/mcpware/pagecast> ·
+Cap <https://github.com/CapSoftware/cap> · Supademo MCP
+<https://supademo.com/blog/product-update-mcp-server> · rmcp (Rust MCP SDK)
+<https://github.com/modelcontextprotocol/rust-sdk> · Playwright MCP
+<https://github.com/microsoft/playwright-mcp> · Microsoft UFO²
+<https://github.com/microsoft/UFO> · Anthropic Computer Use
+<https://platform.claude.com/docs/en/docs/agents-and-tools/computer-use> · Claude Vision
+<https://docs.claude.com/en/docs/build-with-claude/vision> · MLLM-as-a-Judge
+<https://arxiv.org/abs/2402.04788> · ReLook <https://arxiv.org/abs/2510.11498> ·
+Vision-guided refinement <https://arxiv.org/html/2604.05839v1> · MSLLHOOKSTRUCT
+<https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-msllhookstruct>

--- a/docs/AI_DEMO_DIRECTOR.md
+++ b/docs/AI_DEMO_DIRECTOR.md
@@ -1,26 +1,38 @@
 # AI Demo Director (MCP) — Setup & Usage
 
 Vuoom can be driven by an AI agent (e.g. Claude) to **generate a demo GIF/MP4 from a
-plain-English request**: the agent drives a target app, Vuoom records it with cinematic
-auto-zoom, and the agent then *looks at* the result and re-records to improve it. This is
-Vuoom's differentiator — see `docs/13-AI-Demo-Director-Research.md` for the research & rationale.
+plain-English request**: the agent *sees* the screen, drives a target app with humanized
+input, Vuoom records it with cinematic auto-zoom, and the agent then looks at the result,
+critiques it, and **repairs the clip in place** (or re-records). This is Vuoom's
+differentiator — see `docs/13-AI-Demo-Director-Research.md` for the research & rationale.
 
 ## How it fits together
 
 ```
- AI agent (Claude)  ──stdio(MCP)──▶  vuoom-mcp  ──TCP 127.0.0.1 (JSON)──▶  Vuoom control server
-   the "director"                    (sidecar)        vuoom-control            (in the running app)
-                                                                              │
-                                              Session (record / edit / export) + SendInput injection
+ AI agent (Claude)  ──stdio(MCP)──▶  vuoom-mcp  ──TCP 127.0.0.1 (JSON+token)──▶  Vuoom control server
+   the "director"                    (sidecar)        vuoom-control                (in the running app)
+                                                                                  │
+                                          Session (record / edit / export jobs) + humanized SendInput
 ```
 
 - **`vuoom-mcp`** — a standalone MCP server (one binary). The agent launches it over stdio.
-- **`vuoom-control`** — the shared request/response protocol (newline-delimited JSON).
-- **Control server** — runs *inside* Vuoom, **opt-in** via `VUOOM_ENABLE_CONTROL`, loopback only.
+- **`vuoom-control`** — the shared request/response protocol (newline-delimited JSON) with
+  client timeouts and a per-run auth token.
+- **Control server** — runs *inside* Vuoom, **opt-in** via `VUOOM_ENABLE_CONTROL`, loopback
+  only, and every connection must present the token from the discovery file.
 
-Key design point: injected clicks flow through Vuoom's normal input hook, so a single click
-both **operates the target app** and **drives the auto-zoom** — the agent doesn't manage zoom
-separately. The agent is also the *verify loop*: `get_frames` returns PNGs it can see and critique.
+Key design points:
+
+- **Humanized input.** Injected clicks glide along a minimum-jerk path, settle, then press;
+  text types at ~15 chars/sec with natural jitter; scrolls step one notch at a time; drags
+  hold-glide-release. The hardware cursor is baked into the recorded pixels, so this is what
+  makes the recording look human instead of teleporting. The glide also streams real move
+  events through Vuoom's input hook, so the auto-zoom camera follows a smooth path — a
+  single click both **operates the target app** and **drives the zoom**.
+- **The agent is the verify loop** — `screenshot` before/while driving, `clip_state` +
+  `get_frames` after, then repair with the edit tools instead of re-recording.
+- **Output-timeline sampling.** `get_frames`/`seek` map through trim + cuts + speed exactly
+  like export, so the agent critiques precisely what ships.
 
 ## Setup
 
@@ -34,7 +46,9 @@ separately. The agent is also the *verify loop*: `get_frames` returns PNGs it ca
    ```powershell
    $env:VUOOM_ENABLE_CONTROL = "1"; .\Vuoom.exe
    ```
-   On start it writes its chosen port to `%TEMP%\vuoom-control.json` so the sidecar can find it.
+   On start it writes its port **and a random auth token** to `%TEMP%\vuoom-control.json`
+   so the sidecar can find it (the file is removed on exit). Setting the variable to `0`,
+   `false`, or `off` keeps the server disabled.
 
 3. **Register the MCP server** with your agent. For Claude Code / Claude Desktop:
    ```json
@@ -44,47 +58,86 @@ separately. The agent is also the *verify loop*: `get_frames` returns PNGs it ca
      }
    }
    ```
-   (Optional: set `VUOOM_CONTROL_PORT` to pin a port instead of using the discovery file.)
+   (Optional: set `VUOOM_CONTROL_PORT` to pin a port; the token still comes from the
+   discovery file.)
 
 ## Tools
 
+**See & configure**
+
 | Tool | What it does |
 |---|---|
-| `ping` | Check the control server is reachable. |
-| `screen_geometry` | Virtual-desktop bounds (physical px) — call first to reason about coordinates. |
+| `ping` / `status` | Liveness; `{state: idle\|recording\|paused\|clip_ready, elapsed}`. |
+| `screen_geometry` | Virtual-desktop bounds (physical px) — call first. |
+| `screenshot` | PNG of the recording monitor **right now** — locate targets, verify UI state. |
 | `set_region` / `set_zoom_amount` | Configure the next recording (region; zoom 1.0–4.0). |
-| `start_recording` / `stop_recording` | Begin / end capture; stop returns `{duration, frames, zooms}`. |
+| `set_zoom_style` | Tune hold / pre-roll / spring half-lives for the next recording. |
+
+**Record & drive**
+
+| Tool | What it does |
+|---|---|
+| `start_recording` | Begin capture; clicks seed cinematic zooms (`auto_zoom_on_click=false` to opt out). |
+| `stop_recording` / `cancel_recording` | Build the editable clip / discard the take. |
 | `set_paused` | Pause/resume (a paused span becomes a cut). |
-| `click` / `move_cursor` / `type_text` / `key_chord` / `scroll` | Drive the target app (clicks also trigger auto-zoom). |
-| `wait` | Sleep N ms so the target app can settle between actions. |
-| `seek` | Composite the preview frame at a time. |
-| `clip_state` | `{duration, zooms, cuts, speed_regions}`. |
-| `get_frames` | Sample given times → **PNG images** so the agent can see and critique the output. |
+| `click` / `move_cursor` / `drag` | Humanized pointer: minimum-jerk glide, settle, press. |
+| `type_text` / `key_chord` / `scroll` | Paced typing (`cps`), chords incl. punctuation, stepped scrolling. |
+| `wait` | Sleep up to 15 s — give the UI time to react on camera. |
+
+**Critique & repair**
+
+| Tool | What it does |
+|---|---|
+| `clip_state` | `{duration, output_duration, zooms:[{start,end,amount,focus}], cuts, speeds}`. |
+| `get_frames` | Sample output-timeline times (≤16) → **PNG images** to see what exports. |
+| `seek` | Publish a preview frame at an output-timeline time. |
+| `add_zoom` / `update_zoom` / `set_zoom_focus` / `remove_zoom` | Fix zoom timing, strength, centring — no re-record. |
+| `add_cut` / `update_cut` / `remove_cut` | Remove dead air / mistakes. |
+| `auto_speed` / `clear_speed` / `set_trim` | Skim idle stretches; trim the ends. |
+
+**Export**
+
+| Tool | What it does |
+|---|---|
 | `estimate_gif` | Predicted GIF size in bytes. |
-| `export_gif` / `export_mp4` | Write the final clip to a path. |
+| `export_gif` / `export_mp4` | Start an export **job**; returns the id immediately. |
+| `export_status` | Poll `{done, total, finished, error, path}` until `finished`. |
 
 ## Example agent workflow
 
-1. `screen_geometry` → learn the desktop bounds.
+1. `screen_geometry`, then `screenshot` → see the screen, locate what to click.
 2. `set_region` (or full screen) and `set_zoom_amount` (e.g. 2.0).
 3. `start_recording`.
-4. Drive the target: `click`, `type_text`, `key_chord`, `wait` between steps. Each click is
-   auto-zoomed.
-5. `stop_recording`.
-6. `get_frames` at a few times (e.g. around each zoom) → inspect: is the zoom centred? is text
-   legible? any dead air? If not, adjust and re-record.
-7. `export_gif` (or `export_mp4`).
+4. Drive the target: `click`, `type_text`, `key_chord`, `drag` — **wait 800–1500 ms after
+   each action** so the UI reacts on camera; `screenshot` mid-take when unsure. Finish with
+   `wait 2500` so the final zoom-out completes.
+5. `stop_recording` (or `cancel_recording` if the take went wrong).
+6. `clip_state` → learn where the zooms are; `get_frames` around each zoom → inspect: is the
+   zoom centred? is text legible? any dead air?
+7. **Repair in place**: `set_zoom_focus` for a mis-centred zoom, `update_zoom` for one that
+   leaves too early, `remove_zoom` for a misclick, `add_cut`/`auto_speed` for dead air,
+   `set_trim` for awkward ends. Re-record only if the on-screen content itself is wrong;
+   cap the loop at 3–4 takes.
+8. `estimate_gif`, then `export_gif` / `export_mp4` and poll `export_status`.
 
 ## Safety
 
-- The control server is **opt-in** (`VUOOM_ENABLE_CONTROL`) and binds **loopback only**.
-- It can inject real mouse/keyboard, so run demos against a known target and keep credentials
-  off-screen. Closing Vuoom (or unsetting the env var) disables it.
+- The control server is **opt-in** (`VUOOM_ENABLE_CONTROL`), binds **loopback only**, and
+  requires the per-run **auth token** from the discovery file on every connection — another
+  local process cannot drive input injection just by finding the port.
+- Injection failures are **loud**: if Windows blocks synthetic input (e.g. the target app is
+  elevated / UIPI), the tool call errors instead of recording a demo of nothing happening.
+- It can inject real mouse/keyboard, so run demos against a known target and keep
+  credentials off-screen. Closing Vuoom (or unsetting the env var) disables it and removes
+  the discovery file.
 
 ## Verification status
 
-- **CI-verified (compile + unit tests):** `vuoom-control` protocol round-trips, injection
-  coordinate/key math, the `vuoom-mcp` server builds and (locally) lists all tools over stdio.
-- **Needs a real Windows machine (runtime):** actual `SendInput` driving a target app, capture +
-  auto-zoom from injected clicks, and the full record→get_frames→export loop — these need a GPU +
-  interactive session (CI is headless), the same as the rest of Vuoom's capture/GPU paths.
+- **CI-verified (compile + unit/integration tests):** protocol round-trips (incl. optional
+  pacing fields), the auth handshake (`vuoom-control` client↔server integration test), the
+  humanizer's pure math (min-jerk path, durations, jitter, extended/OEM key maps), and that
+  the `vuoom-mcp` router registers every director tool.
+- **Needs a real Windows machine (runtime):** actual `SendInput` driving a target app,
+  capture + auto-zoom from injected clicks, and the full record→critique→repair→export loop
+  — these need a GPU + interactive session (CI is headless), the same as the rest of
+  Vuoom's capture/GPU paths.

--- a/docs/AI_DEMO_DIRECTOR.md
+++ b/docs/AI_DEMO_DIRECTOR.md
@@ -42,6 +42,13 @@ Key design points:
    ```
    Binary: `target/release/vuoom-mcp.exe`.
 
+   > **After changing the control protocol or adding tools** (e.g. the `preview_clip`,
+   > `list_windows`, `set_region_to_window` tools, or the new `auto_speed` params), you must
+   > **rebuild `vuoom-mcp` and reconnect the MCP server** (in Claude Code, `/mcp`) with Vuoom
+   > running under `VUOOM_ENABLE_CONTROL=1` — the agent otherwise keeps talking to a stale
+   > sidecar that lacks the new tools. There is no separate `target-mcp/` build; the canonical
+   > binary is `target/release/vuoom-mcp.exe`.
+
 2. **Run Vuoom with the control server enabled** (it is off by default for safety):
    ```powershell
    $env:VUOOM_ENABLE_CONTROL = "1"; .\Vuoom.exe
@@ -71,6 +78,8 @@ Key design points:
 | `screen_geometry` | Virtual-desktop bounds (physical px) — call first. |
 | `screenshot` | PNG of the recording monitor **right now** — locate targets, verify UI state. |
 | `set_region` / `set_zoom_amount` | Configure the next recording (region; zoom 1.0–4.0). |
+| `list_windows` | Enumerate visible top-level windows (topmost first) with physical-px bounds `[{title,x,y,w,h}]`. |
+| `set_region_to_window` | Snap the capture region to a window's current bounds (best title match, optional `padding`) — no pixel-math. Returns the resolved region. Does **not** hide windows drawn above the target. |
 | `set_zoom_style` | Tune hold / pre-roll / spring half-lives for the next recording. |
 
 **Record & drive**
@@ -90,10 +99,11 @@ Key design points:
 |---|---|
 | `clip_state` | `{duration, output_duration, zooms:[{start,end,amount,focus}], cuts, speeds}`. |
 | `get_frames` | Sample output-timeline times (≤16) → **PNG images** to see what exports. |
+| `preview_clip` | Cheap low-res **animated GIF** over `[start,end]` (output secs, ≤~120 frames) to critique motion/pacing/easing before a full export — not a deliverable. |
 | `seek` | Publish a preview frame at an output-timeline time. |
 | `add_zoom` / `update_zoom` / `set_zoom_focus` / `remove_zoom` | Fix zoom timing, strength, centring — no re-record. |
 | `add_cut` / `update_cut` / `remove_cut` | Remove dead air / mistakes. |
-| `auto_speed` / `clear_speed` / `set_trim` | Skim idle stretches; trim the ends. |
+| `auto_speed` / `clear_speed` / `set_trim` | Skim idle stretches (`auto_speed` takes optional `min_gap`/`lead`/`tail`); trim the ends. |
 
 **Export**
 

--- a/docs/AI_DEMO_DIRECTOR.md
+++ b/docs/AI_DEMO_DIRECTOR.md
@@ -1,0 +1,90 @@
+# AI Demo Director (MCP) — Setup & Usage
+
+Vuoom can be driven by an AI agent (e.g. Claude) to **generate a demo GIF/MP4 from a
+plain-English request**: the agent drives a target app, Vuoom records it with cinematic
+auto-zoom, and the agent then *looks at* the result and re-records to improve it. This is
+Vuoom's differentiator — see `docs/13-AI-Demo-Director-Research.md` for the research & rationale.
+
+## How it fits together
+
+```
+ AI agent (Claude)  ──stdio(MCP)──▶  vuoom-mcp  ──TCP 127.0.0.1 (JSON)──▶  Vuoom control server
+   the "director"                    (sidecar)        vuoom-control            (in the running app)
+                                                                              │
+                                              Session (record / edit / export) + SendInput injection
+```
+
+- **`vuoom-mcp`** — a standalone MCP server (one binary). The agent launches it over stdio.
+- **`vuoom-control`** — the shared request/response protocol (newline-delimited JSON).
+- **Control server** — runs *inside* Vuoom, **opt-in** via `VUOOM_ENABLE_CONTROL`, loopback only.
+
+Key design point: injected clicks flow through Vuoom's normal input hook, so a single click
+both **operates the target app** and **drives the auto-zoom** — the agent doesn't manage zoom
+separately. The agent is also the *verify loop*: `get_frames` returns PNGs it can see and critique.
+
+## Setup
+
+1. **Build the sidecar** (CI also produces it):
+   ```
+   cargo build --release -p vuoom-mcp
+   ```
+   Binary: `target/release/vuoom-mcp.exe`.
+
+2. **Run Vuoom with the control server enabled** (it is off by default for safety):
+   ```powershell
+   $env:VUOOM_ENABLE_CONTROL = "1"; .\Vuoom.exe
+   ```
+   On start it writes its chosen port to `%TEMP%\vuoom-control.json` so the sidecar can find it.
+
+3. **Register the MCP server** with your agent. For Claude Code / Claude Desktop:
+   ```json
+   {
+     "mcpServers": {
+       "vuoom": { "command": "C:\\path\\to\\vuoom-mcp.exe" }
+     }
+   }
+   ```
+   (Optional: set `VUOOM_CONTROL_PORT` to pin a port instead of using the discovery file.)
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `ping` | Check the control server is reachable. |
+| `screen_geometry` | Virtual-desktop bounds (physical px) — call first to reason about coordinates. |
+| `set_region` / `set_zoom_amount` | Configure the next recording (region; zoom 1.0–4.0). |
+| `start_recording` / `stop_recording` | Begin / end capture; stop returns `{duration, frames, zooms}`. |
+| `set_paused` | Pause/resume (a paused span becomes a cut). |
+| `click` / `move_cursor` / `type_text` / `key_chord` / `scroll` | Drive the target app (clicks also trigger auto-zoom). |
+| `wait` | Sleep N ms so the target app can settle between actions. |
+| `seek` | Composite the preview frame at a time. |
+| `clip_state` | `{duration, zooms, cuts, speed_regions}`. |
+| `get_frames` | Sample given times → **PNG images** so the agent can see and critique the output. |
+| `estimate_gif` | Predicted GIF size in bytes. |
+| `export_gif` / `export_mp4` | Write the final clip to a path. |
+
+## Example agent workflow
+
+1. `screen_geometry` → learn the desktop bounds.
+2. `set_region` (or full screen) and `set_zoom_amount` (e.g. 2.0).
+3. `start_recording`.
+4. Drive the target: `click`, `type_text`, `key_chord`, `wait` between steps. Each click is
+   auto-zoomed.
+5. `stop_recording`.
+6. `get_frames` at a few times (e.g. around each zoom) → inspect: is the zoom centred? is text
+   legible? any dead air? If not, adjust and re-record.
+7. `export_gif` (or `export_mp4`).
+
+## Safety
+
+- The control server is **opt-in** (`VUOOM_ENABLE_CONTROL`) and binds **loopback only**.
+- It can inject real mouse/keyboard, so run demos against a known target and keep credentials
+  off-screen. Closing Vuoom (or unsetting the env var) disables it.
+
+## Verification status
+
+- **CI-verified (compile + unit tests):** `vuoom-control` protocol round-trips, injection
+  coordinate/key math, the `vuoom-mcp` server builds and (locally) lists all tools over stdio.
+- **Needs a real Windows machine (runtime):** actual `SendInput` driving a target app, capture +
+  auto-zoom from injected clicks, and the full record→get_frames→export loop — these need a GPU +
+  interactive session (CI is headless), the same as the rest of Vuoom's capture/GPU paths.

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -77,6 +77,23 @@ a GPU-less CI runner, so they're compile-verified here and confirmed by running 
 
 ---
 
+## AI Demo Director (MCP) — agent-driven demo generation
+
+An AI agent (Claude) can drive Vuoom to generate a demo: drive a target app, record with
+auto-zoom, *see* the output via sampled frames, and re-record to improve it. Setup in
+`docs/AI_DEMO_DIRECTOR.md`; research in `docs/13-AI-Demo-Director-Research.md`.
+
+| Area | Crate | Status |
+|---|---|---|
+| Control protocol (newline-JSON req/resp, client, port discovery) | `vuoom-control` | ✅ |
+| Input injection (SendInput move/click/type/key/scroll) + coord/key math | `vuoom-input` | 🟡 (math ✅; SendInput runtime) |
+| In-app control server (opt-in `VUOOM_ENABLE_CONTROL`, loopback) | `src-tauri` | 🟡 |
+| `Session::sample_frames` (composite → base64 PNG) + `clip_info` | `src-tauri` | 🟡 |
+| MCP sidecar — 19 tools over stdio (rmcp) | `vuoom-mcp` | ✅ (builds + `tools/list` smoke-tested) |
+
+Runtime-verify on a real machine: actual SendInput driving a target app, capture + auto-zoom
+from injected clicks, and the full record→get_frames→export loop (CI is headless/GPU-less).
+
 ## Why the 🟡 / ⬜ boundary
 
 The capture, GPU compositor, and live preview need a **real GPU + display** to verify (does it

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -86,13 +86,17 @@ auto-zoom, *see* the output via sampled frames, and re-record to improve it. Set
 | Area | Crate | Status |
 |---|---|---|
 | Control protocol (newline-JSON req/resp, client, port discovery) | `vuoom-control` | ✅ |
-| Input injection (SendInput move/click/type/key/scroll) + coord/key math | `vuoom-input` | 🟡 (math ✅; SendInput runtime) |
-| In-app control server (opt-in `VUOOM_ENABLE_CONTROL`, loopback) | `src-tauri` | 🟡 |
-| `Session::sample_frames` (composite → base64 PNG) + `clip_info` | `src-tauri` | 🟡 |
-| MCP sidecar — 19 tools over stdio (rmcp) | `vuoom-mcp` | ✅ (builds + `tools/list` smoke-tested) |
+| Input injection (SendInput move/click/type/key/scroll) + coord/key math | `vuoom-input` | ✅ runtime-verified |
+| In-app control server (opt-in `VUOOM_ENABLE_CONTROL`, loopback) | `src-tauri` | ✅ runtime-verified |
+| `Session::sample_frames` (composite → base64 PNG) + `clip_info` | `src-tauri` | ✅ runtime-verified |
+| MCP sidecar — 20 tools over stdio (rmcp) | `vuoom-mcp` | ✅ runtime-verified |
+| Click-to-zoom for agent recordings (`SetAutoZoomOnClick`, default on) | all | ✅ runtime-verified |
 
-Runtime-verify on a real machine: actual SendInput driving a target app, capture + auto-zoom
-from injected clicks, and the full record→get_frames→export loop (CI is headless/GPU-less).
+**Runtime-verified on a real Windows machine (2026-06-14):** a sequential MCP agent drove the
+live app end to end — `start_recording` → injected clicks/typing into a target app (Notepad) →
+`stop_recording` (158 frames, **1 cinematic zoom planned from the injected clicks**) →
+`get_frames` (real composited PNGs) → `export_gif` (real GIF written). The one runtime bug found
+and fixed: click-to-zoom defaults off for the interactive UI, so the agent path now opts it on.
 
 ## Why the 🟡 / ⬜ boundary
 

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -98,6 +98,20 @@ live app end to end — `start_recording` → injected clicks/typing into a targ
 `get_frames` (real composited PNGs) → `export_gif` (real GIF written). The one runtime bug found
 and fixed: click-to-zoom defaults off for the interactive UI, so the agent path now opts it on.
 
+**v2 (2026-07-02, from the `mcp_improve.md` review — 🟡 needs a fresh runtime pass):**
+
+| Area | Crate | Status |
+|---|---|---|
+| Humanized injection: min-jerk cursor glide, settle-then-click, paced typing, stepped scroll, drag | `vuoom-input` | 🟡 compile+unit-tested |
+| Injection failure detection (UIPI short-count → error), extended keys, OEM punctuation | `vuoom-input` | 🟡 |
+| Live `screenshot` op + `status` / `cancel_recording` | all | 🟡 |
+| `clip_state` returns zoom/cut/speed **spans** + `output_duration` | all | 🟡 |
+| Output-timeline `get_frames`/`seek` (matches export through trim/cuts/speed) | `src-tauri` | 🟡 |
+| Edit ops over the protocol (zoom/cut/speed/trim repair without re-recording) | all | 🟡 |
+| Job-based exports with `export_status` polling | all | 🟡 |
+| Auth token + connect/read timeouts + discovery-file cleanup + `VUOOM_ENABLE_CONTROL=0` off | all | ✅ CI (auth integration test) |
+| Per-recording `set_zoom_style` + agent flags reset at stop/cancel | `src-tauri` | 🟡 |
+
 ## Why the 🟡 / ⬜ boundary
 
 The capture, GPU compositor, and live preview need a **real GPU + display** to verify (does it

--- a/docs/demo_director_fix_plan.md
+++ b/docs/demo_director_fix_plan.md
@@ -27,24 +27,26 @@ except where a missing feature blocks them.
 
 ## 2. Fix plan (prioritized)
 
+**Status (2026-07-03):** Tier 1 (1–3) ✅ done · Tier 2 (5–8) ✅ done · Tier 3 (9) ✅ done · Tier 3 (10) ◑ partial (region-snap shipped; true window-target capture deferred). Item 4 is a housekeeping note (see the MCP docs' sidecar section).
+
 ### Tier 1 — small verified bug fixes (hours)
 
-1. **`key_chord` symbol keys** — in `key_to_vk` (`inject.rs`), map `"+"|"add"`→`VK_ADD` (0x6B — emits a literal `+` unshifted, unlike OEM_PLUS), `"*"|"multiply"|"asterisk"`→`VK_MULTIPLY` (0x6A), plus `subtract/divide/decimal/numpad0-9`. Unit test alongside `oem_punctuation_maps` (`inject.rs:651`). No control-server/MCP changes needed.
-2. **`auto_speed` ergonomics** — surface `min_gap`/`lead`/`tail` as optional params on the MCP tool (defaults unchanged) AND state the 2.5 s threshold in the tool description so the agent doesn't trial-and-error it.
-3. **Expose camera path in `clip_state`** — add sampled `(t, cx, cy, zoom)` from the already-computed `CameraTrack` to `ClipInfo`, and report the effective focus for Auto spans instead of `None`. This un-blinds the repair loop for wander/framing critique.
-4. **Sidecar hygiene** — delete the divergent `target-mcp/` dir; document "rebuild → `/mcp` reconnect" in the MCP docs.
+1. ✅ **DONE — `key_chord` symbol keys** — in `key_to_vk` (`inject.rs`), map `"+"|"add"`→`VK_ADD` (0x6B — emits a literal `+` unshifted, unlike OEM_PLUS), `"*"|"multiply"|"asterisk"`→`VK_MULTIPLY` (0x6A), plus `subtract/divide/decimal/numpad0-9`. Unit test alongside `oem_punctuation_maps` (`inject.rs:651`). No control-server/MCP changes needed.
+2. ✅ **DONE — `auto_speed` ergonomics** — `min_gap`/`lead`/`tail` are now optional params on `AutoSpeed`/`auto_speed` (defaults 2.5/0.6/0.4 preserve prior behaviour exactly, clamps 0.5–30 / 0–5 / 0–5), and the tool description states the semantics so the agent doesn't trial-and-error `factor`. (`session.rs::auto_speed`, `control_server.rs`, `vuoom-mcp/src/main.rs`.)
+3. ✅ **DONE — Expose camera path in `clip_state`** — sampled `(t, cx, cy, zoom)` from the already-computed `CameraTrack` is in `ClipInfo.camera`, and Auto spans report an effective focus. This un-blinds the repair loop for wander/framing critique.
+4. **Sidecar hygiene** — delete the divergent `target-mcp/` dir; document "rebuild → `/mcp` reconnect" in the MCP docs (see the new tools section in `AI_DEMO_DIRECTOR.md`).
 
 ### Tier 2 — camera/direction features (the perceived-quality wins)
 
-5. **Rect focus** — new `ZoomMode::Rect { rect }`; camera derives zoom = fit-rect-with-padding and focus = rect center. Extend `set_zoom_focus`/`add_zoom` to accept an optional rect. This is the "zoom to the result, not the cursor" enabler — the agent screenshots, finds the result region, and frames *that*.
-6. **Expose merge/behavior knobs** — add `merge_gap`, `merge_radius`, `min_rezoom_interval`, `dead_zone` to `set_zoom_style` so "don't merge my 4 clicks" / "one deliberate zoom" is an API call, not a recompile.
-7. **Per-span envelope** — optional `hl_zoom_in`/`hl_zoom_out` (and/or explicit hold) on `ZoomKeyframe`, settable via `update_zoom`, so a reveal span can ease slower and hold longer than setup spans.
-8. **Caret-follow** — emit a position on `KeyType` events (caret/last-injection point) so `Auto` spans pan with typing; fixes "text runs off the right edge" without new camera machinery.
+5. ✅ **DONE — Rect focus** — `ZoomMode::Rect { rect }`; camera derives zoom = fit-rect-with-padding and focus = rect center. `set_zoom_focus`/`add_zoom` accept an optional rect.
+6. ✅ **DONE — Expose merge/behavior knobs** — `merge_gap`, `merge_radius`, `min_rezoom_interval`, `dead_zone` are on `set_zoom_style`.
+7. ✅ **DONE — Per-span envelope** — optional `hl_zoom_in`/`hl_zoom_out` on `ZoomKeyframe`, settable via `update_zoom`/`add_zoom`.
+8. ✅ **DONE — Caret-follow** — `KeyType` events carry an injected-pointer/caret position so `Auto` spans pan with typing.
 
 ### Tier 3 — bigger product gaps
 
-9. **Motion preview over the control protocol** — `PreviewClip { start, end, fps, width }`: reuse the `sample_frames` compositing loop over a range, encode a small low-res GIF with the existing encoder, return base64. Closes the "critique loop can't see motion" gap without full exports.
-10. **Window-targeted capture** — two steps: (a) cheap: window-bounds helper (`DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)`) + `set_region_to_window(title)` that snaps the existing `CropRegion` — kills the pixel-math, not the occlusion; (b) real: `windows_capture::window::Window` capture target parallel to `pick_monitor` — kills occlusion/overlay bleed entirely. This is the single biggest robustness win for AI-driven demos.
+9. ✅ **DONE — Motion preview over the control protocol** — `PreviewClip { start, end, fps, width }` reuses the `sample_frames` compositing loop over a range, encodes a small low-res GIF in-process with the existing `export_gif_native` (single global-palette pass, no lossy second pass), and returns it as base64. Implemented as a **synchronous** request (bounded ≤120 low-res frames, well inside the client read timeout) rather than an async export job. MCP tool `preview_clip` returns the GIF as `image/gif` content plus a metadata JSON block. Closes the "critique loop can't see motion" gap without full exports.
+10. ◑ **PARTIAL — Window-targeted capture** — (a) ✅ **shipped**: window-bounds helpers (`vuoom_capture::{list_windows, find_window_bounds}` via `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)`) + `ListWindows` and `SetRegionToWindow { title, padding }` requests (MCP tools `list_windows`, `set_region_to_window`) that snap the existing `CropRegion` through the normal `set_region` path — kills the pixel-math, not the occlusion. (b) ⏸ **deferred**: `CaptureTarget::Window` capture core has landed in `vuoom-capture`, but wiring it into the recording session is deliberately held back — `vuoom-input`'s `normalize.rs` maps raw screen coords relative to the region assuming region == screen-rect, so a window-target capture would break click/zoom mapping. Region-snap is the correct v1; true window-target capture is a future step once normalization is made window-aware.
 
 ### Not code (director playbook — already in issues.md §3–4)
 

--- a/docs/demo_director_fix_plan.md
+++ b/docs/demo_director_fix_plan.md
@@ -1,0 +1,53 @@
+# AI Demo Director — Verified Issues & Fix Plan
+
+**Date:** 2026-07-03
+**Input:** `demo-output/issues.md` (critique of the 2026-07-02 demo run)
+**Method:** every technical claim in that report was independently verified against the code
+(file:line evidence below). Nothing was accepted on faith. Craft/directing observations
+(sections 3, 4, 6 of the report) are process guidance, not code bugs, and are out of scope here
+except where a missing feature blocks them.
+
+---
+
+## 1. Claim-by-claim verdicts
+
+| # | Claim (issues.md) | Verdict | Root cause / evidence |
+|---|---|---|---|
+| 1 | `key_chord ["+"]` errors; calc showed 789 | **CONFIRMED** | `key_to_vk` (`crates/vuoom-input/src/inject.rs:124-161`) has no `"+"` entry; fallthrough `single_key_vk` (`:164-175`) rejects it → `control_server.rs:289-291` returns `unknown key: +` (hard error, not silent). Digits/enter resolved, each `+` call errored → keystrokes reaching calc were `7 8 9 Enter` = 789. **Latent bug:** `"plus"`/`"="` map to `VK_OEM_PLUS` (0xBB) which types `=` unshifted and `key_chord` never synthesizes Shift — so today NO key name can type a literal `+`. |
+| 2 | Camera tracks the pointer, not the point of change; no content-rect focus | **CONFIRMED** | `ZoomMode` is only `Auto` (spring-smoothed cursor follow, `camera.rs:174-184`) or `Manual { pos: DVec2 }` — one fixed normalized point (`keyframe.rs:11-17`). No rect/bbox variant exists. `set_zoom_focus` accepts a point only (`session.rs:1429-1447`). |
+| 3 | 4 clicks merged into one ~6.5 s wandering zoom | **CONFIRMED** | Clustering: click joins previous cluster if gap ≤ `merge_gap` 0.8 s AND distance ≤ `merge_radius` 0.15 (`planner.rs:96-111`); each click extends `end` by `hold` 1.8 s (`:116-140`); merged span stays `Auto` (`:142-148`) so focus pans across every click point — that IS the wander. 4 clicks over ~2 s + 1.8 hold + 0.3 pre_roll ≈ 6.5 s. Merge knobs are in `ZoomConfig` (`config.rs:41-58`) but NOT exposed via `set_zoom_style` (only hold/pre_roll/hl_zoom/hl_pan, `session.rs:173-182`) → recompile-only today. |
+| 4 | No shot arc / no hold-on-reveal / uniform easing | **CONFIRMED (nuance)** | Envelope is a global critically-damped spring in/out (`camera.rs:32-43,193-197`); release only 0.85× faster; no per-span attack/hold/release or easing. BUT `update_zoom(index,start,end,amount)` + `set_zoom_focus` + `set_zoom_style` already allow retiming/pinning — the last run under-used them. |
+| 5 | Framing ignores content bounds; no pan-to-caret | **CONFIRMED** | Viewport = uniform centered crop of side `1/zoom` (`vuoom-render/src/layout.rs:41-52`); only clamp is to frame edges (`camera.rs:50-58`), never content. `KeyType` events carry **no position** (`event.rs:36-37`) so typing can sustain a hold but can never move focus — caret motion is invisible to the camera. |
+| 6 | Repair loop half-blind | **CONFIRMED ×2** | (a) `clip_state` returns `focus: None` for every Auto span (`session.rs:1031-1034`) — agent cannot see where the camera actually pointed, though a `CameraTrack` is already computed internally (`camera.rs:81`). (b) `get_frames` = PNG stills, max 16 (`session.rs:1064-1114`, `main.rs:29,636`); the live animated compositor (`crates/vuoom-preview`) is a WebSocket wired to the in-app webview only — no motion preview reaches the agent short of a full export. |
+| 7 | Capture is a region, not a window | **CONFIRMED** | WGC **monitor** capture only (`capture.rs:151-179`, `pick_monitor :133-144`); `CropRegion` is a fixed-pixel crop of each monitor frame (`:100-125`) → grabs whatever is topmost. The `windows-capture` crate supports `Window` targets but it's never imported; repo has zero window-enumeration/GetWindowRect helpers (`windows_ext.rs` has only capture-exclusion + clipboard). |
+| 8 | `auto_speed` needs ~5 s idle | **CONFIRMED (refined)** | Hardcoded in `session.rs:1225-1260`: `MIN_GAP=2.5`, `LEAD=0.6`, `TAIL=0.4`, post-trim region must be > 0.5 s. Real cutoff = 2.5 s idle (report guessed ~2 s); only `factor` (1.5–16) is an API param. |
+| 9 | Stale sidecar vs v2 auth | **CONFIRMED, ALREADY REMEDIATED** | Auth handshake: first line must equal the token from `%TEMP%/vuoom-control.json` or the server drops the connection (`control_server.rs:93-104`; auth landed in `66b0992`, 2026-07-02). At demo time `.mcp.json`'s target `target/release/vuoom-mcp.exe` was the Jun-14 pre-auth build. **It has since been rebuilt (2026-07-02 16:17, identical to `target-mcp/release/`)** — no repoint needed; only an MCP reconnect (`/mcp`) with Vuoom running under `VUOOM_ENABLE_CONTROL=1`. |
+
+---
+
+## 2. Fix plan (prioritized)
+
+### Tier 1 — small verified bug fixes (hours)
+
+1. **`key_chord` symbol keys** — in `key_to_vk` (`inject.rs`), map `"+"|"add"`→`VK_ADD` (0x6B — emits a literal `+` unshifted, unlike OEM_PLUS), `"*"|"multiply"|"asterisk"`→`VK_MULTIPLY` (0x6A), plus `subtract/divide/decimal/numpad0-9`. Unit test alongside `oem_punctuation_maps` (`inject.rs:651`). No control-server/MCP changes needed.
+2. **`auto_speed` ergonomics** — surface `min_gap`/`lead`/`tail` as optional params on the MCP tool (defaults unchanged) AND state the 2.5 s threshold in the tool description so the agent doesn't trial-and-error it.
+3. **Expose camera path in `clip_state`** — add sampled `(t, cx, cy, zoom)` from the already-computed `CameraTrack` to `ClipInfo`, and report the effective focus for Auto spans instead of `None`. This un-blinds the repair loop for wander/framing critique.
+4. **Sidecar hygiene** — delete the divergent `target-mcp/` dir; document "rebuild → `/mcp` reconnect" in the MCP docs.
+
+### Tier 2 — camera/direction features (the perceived-quality wins)
+
+5. **Rect focus** — new `ZoomMode::Rect { rect }`; camera derives zoom = fit-rect-with-padding and focus = rect center. Extend `set_zoom_focus`/`add_zoom` to accept an optional rect. This is the "zoom to the result, not the cursor" enabler — the agent screenshots, finds the result region, and frames *that*.
+6. **Expose merge/behavior knobs** — add `merge_gap`, `merge_radius`, `min_rezoom_interval`, `dead_zone` to `set_zoom_style` so "don't merge my 4 clicks" / "one deliberate zoom" is an API call, not a recompile.
+7. **Per-span envelope** — optional `hl_zoom_in`/`hl_zoom_out` (and/or explicit hold) on `ZoomKeyframe`, settable via `update_zoom`, so a reveal span can ease slower and hold longer than setup spans.
+8. **Caret-follow** — emit a position on `KeyType` events (caret/last-injection point) so `Auto` spans pan with typing; fixes "text runs off the right edge" without new camera machinery.
+
+### Tier 3 — bigger product gaps
+
+9. **Motion preview over the control protocol** — `PreviewClip { start, end, fps, width }`: reuse the `sample_frames` compositing loop over a range, encode a small low-res GIF with the existing encoder, return base64. Closes the "critique loop can't see motion" gap without full exports.
+10. **Window-targeted capture** — two steps: (a) cheap: window-bounds helper (`DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)`) + `set_region_to_window(title)` that snaps the existing `CropRegion` — kills the pixel-math, not the occlusion; (b) real: `windows_capture::window::Window` capture target parallel to `pick_monitor` — kills occlusion/overlay bleed entirely. This is the single biggest robustness win for AI-driven demos.
+
+### Not code (director playbook — already in issues.md §3–4)
+
+Storyboard-first, stage frame 1, zoom-to-reveal-once, hold the payoff, loop-friendly ends,
+clean stage (no overlays/terminal). These should become the **prompting playbook** baked into the
+vuoom MCP server instructions once Tier 2 gives the agent the tools to execute them.

--- a/mcp_improve.md
+++ b/mcp_improve.md
@@ -1,0 +1,476 @@
+# MCP / AI Demo Director — Code Review & Improvement Plan
+
+**Branch reviewed:** `feat/ai-demo-director-mcp` (13 commits over `main`)
+**Files reviewed:** `crates/vuoom-mcp`, `crates/vuoom-control`, `crates/vuoom-input/src/inject.rs`,
+`src-tauri/src/control_server.rs`, the `session.rs` additions, and the zoom pipeline
+(`vuoom-zoom/planner.rs`, `camera.rs`, `config.rs`) these recordings flow through.
+
+---
+
+## TL;DR verdict
+
+The architecture is genuinely good. The sidecar split (`vuoom-mcp` ↔ `vuoom-control` ↔ in-app
+server), the newline-JSON protocol with round-trip tests, the "injected input flows through the
+same hook as real input, so one click drives the app AND the zoom" trick — all of that is the
+right design and it's clean, documented code. Nothing here needs a rewrite.
+
+What's wrong is at a different level: **the tools produce robot-looking recordings and the
+critique loop is half-blind.**
+
+1. **The cursor teleports.** `click()` warps the mouse across the screen in a single
+   `SendInput` batch. The hardware cursor is baked into the captured pixels, so the GIF shows
+   a cursor that jumps instantly from A to B. No amount of camera-spring tuning can fix this —
+   the smoothing happens *after* the damage is in the pixels. This is the single biggest reason
+   agent recordings don't look "Screen-Studio smooth."
+2. **Typing appears all at once, scrolling is one big jump, and there is no drag.** Same
+   root cause: injection is instantaneous, real humans take time.
+3. **The agent can't see while driving, doesn't know where the zooms are, and can't fix
+   anything without a full re-record.** `clip_state` returns *counts*, not zoom times; there's
+   no live screenshot; none of the session's existing edit ops (delete zoom, retime, add cut,
+   auto-speed) are exposed.
+
+Fix category 1+2 (a "humanizer" layer in `vuoom-input`) and category 3 (a handful of new
+protocol ops that are one-line wrappers over code that already exists in `session.rs`), and
+this feature goes from "somehow working" to actually delivering the demo-director story.
+
+Everything below is ordered by impact, with file/line pointers and concrete fixes.
+
+---
+
+## Part 1 — Smoothness: why the recordings look robotic
+
+### 1.1 Cursor teleportation is baked into the pixels (P0, the big one)
+
+**Where:**
+- `crates/vuoom-input/src/inject.rs:166` — `click()` sends `abs_move + down + up` in **one**
+  `SendInput` batch. The cursor moves 0→100% of the distance in a single event.
+- `crates/vuoom-capture/src/capture.rs:169` — `CursorCaptureSettings::Default` means Windows
+  Graphics Capture draws the **hardware cursor into the frame pixels**.
+
+**Consequence:** in the exported GIF the pointer visibly *teleports* between click targets.
+The camera pre-smoothing spring (`camera.rs:161`, `hl_cursor = 0.12s`) only smooths the
+*camera focus*, not the visible pointer — the pointer itself is already burned into the
+captured frames. Two further knock-on effects:
+
+- **Camera whip.** A cross-screen teleport is a step-function input to the pan spring. With
+  `hl_pan = 0.22s` the camera races across the frame at high peak velocity; at 20 fps GIF
+  output with no motion blur, that reads as a jerk, not a glide.
+- **Zoom centring races the click.** The planner's `pre_roll = 0.3s` starts the zoom-in
+  *before* the click (good), but the cursor only arrives at the click position at the exact
+  click instant — so during the anticipation window the camera is zooming toward a point the
+  pointer isn't at yet.
+
+**Fix (recommended): humanized cursor motion in `vuoom-input`.**
+
+Add an eased, interpolated move and make `click` glide by default:
+
+```rust
+/// Glide the cursor from its current position to (x, y) over `duration`,
+/// injecting absolute moves at ~120 Hz along a minimum-jerk profile.
+pub fn move_cursor_smooth(x: i32, y: i32, duration_ms: u32) {
+    // s(t) = 10t^3 - 15t^4 + 6t^5  (minimum-jerk; starts and ends at zero velocity)
+    // sample every ~8 ms; add a ±1px of low-amplitude noise if you want extra realism
+}
+```
+
+- Duration should scale with distance (Fitts-like), e.g.
+  `clamp(150 + px_distance / 3, 200, 900)` ms. Expose it as an optional `duration_ms`
+  param on `move_cursor` / `click` so the agent can override pacing.
+- `click()` becomes: glide → settle ~100–150 ms → down → 40–80 ms → up. The settle pause
+  matters twice: it looks deliberate, *and* it gives the camera's pre-roll a stationary
+  target to zoom toward.
+- Use `GetCursorPos` for the start point so the path is continuous from wherever the
+  pointer currently is.
+- Bonus: the glide generates a stream of `WM_MOUSEMOVE` hook events, so the recorded cursor
+  track (which the camera follows) becomes a real path instead of a step function — the pan
+  spring output becomes silky *for free*.
+
+**Fix (bigger, optional but the "pro" endgame): synthetic cursor rendering.**
+Capture with `CursorCaptureSettings::WithoutCursor` and draw the cursor in the compositor
+from the (smoothed) input track — the Screen Studio approach. That decouples the visible
+pointer from OS jitter entirely, lets you scale the cursor when zoomed in, ease it
+independently, and even smooth *human* recordings. This is a bigger lift (cursor sprite
+rendering in `vuoom-render`) and can come after the humanizer, but it's where "fully
+smooth and perfect" ultimately lives. Consider it the v2 of cursor flow.
+
+### 1.2 Typing appears instantaneously (P0)
+
+**Where:** `crates/vuoom-input/src/inject.rs:232` — `type_text` pushes one down/up pair per
+UTF-16 unit into a **single** `SendInput` batch. A whole sentence materializes in ~0 ms.
+
+**Consequences:**
+- In the GIF, text pops into existence — instantly recognizable as fake.
+- The zoom hold logic (`planner.rs`, activity extension) sees all key events at essentially
+  the same timestamp, so a "typing" zoom doesn't sustain the way it would for a human; the
+  camera can zoom out mid-"typing".
+- Some apps drop events when a huge batch arrives at once.
+
+**Fix:** pace it. Add an optional `cps` (or `delay_ms`) parameter to `TypeText` (protocol +
+tool), default ~12–18 chars/sec with ±30% jitter, injecting one char (or one key pair) per
+tick. Trivial to implement server-side with `std::thread::sleep` on the connection thread.
+Paced key events also sustain the zoom hold correctly because each keystroke is a fresh
+activity timestamp.
+
+### 1.3 Scroll is one violent jump (P1)
+
+**Where:** `inject.rs:185` — `scroll()` sends the *entire* delta as a single wheel event
+(`delta * WHEEL_DELTA`).
+
+**Fix:** step it — one notch every 30–60 ms (optionally with an eased distribution: fast
+in the middle, slow at the ends). Smooth-scrolling apps animate nicer with several small
+deltas, and the recorded motion reads as intentional. Add optional `duration_ms`.
+
+### 1.4 There is no drag (P1)
+
+Sliders, drag-and-drop, text selection, window moves — common demo actions — are impossible
+with the current tool set. Add:
+
+```
+drag { x1, y1, x2, y2, button?, duration_ms? }
+```
+
+= glide to (x1,y1) → button down → eased move path to (x2,y2) (the same humanizer path
+generator as 1.1) → button up. Drag-starts already count as zoom triggers in the planner
+(`is_click_trigger`), so this integrates with auto-zoom for free.
+
+### 1.5 Rhythm is entirely the agent's problem (P2)
+
+The demo's pacing currently depends on the agent remembering to call `wait` with good
+values. Two cheap improvements:
+
+- Put a concrete **rhythm recipe** in the MCP `INSTRUCTIONS` string (`vuoom-mcp/src/main.rs:487`),
+  e.g.: *"per step: move (auto-glide) → wait 300–500 ms → click → wait 800–1500 ms for the
+  UI to react; keep total takes under ~30 s; end with wait 1000 ms so the final zoom-out
+  completes before stop_recording."* The last point matters: if the agent stops recording
+  immediately after the last click, the clip ends mid-zoom — always advise a tail wait
+  ≥ `hold + zoom-out time` (~2.5 s).
+- Optionally: a server-side `min_action_gap_ms` so back-to-back injections are never
+  physically implausible even if the agent forgets to wait.
+
+### 1.6 Zoom-config defaults are tuned for humans, not agents (P2)
+
+`ZoomConfig::default()` (`vuoom-zoom/src/config.rs:44`) — `merge_gap 0.8`, `hold 1.8`,
+`min_rezoom_interval 1.0` — were tuned for noisy human clicking. Agent clicks are sparse and
+deliberate, so the defaults mostly work, but the agent has no way to adjust feel (e.g. longer
+`hold` for a slow narration-style demo, tighter `pre_roll`). Consider one protocol op:
+
+```
+set_zoom_style { hold?, pre_roll?, hl_zoom?, hl_pan? }   // for the NEXT recording
+```
+
+Not urgent, but it's the knob the critique loop will eventually want ("the zoom leaves too
+early → increase hold → re-record" is a much better iteration than blind re-recording).
+
+---
+
+## Part 2 — The critique loop is half-blind
+
+The whole moat (per `docs/13-AI-Demo-Director-Research.md`) is *record → watch → critique →
+improve*. Right now the "watch" and "improve" halves are severely under-equipped.
+
+### 2.1 The agent cannot see the screen while driving (P0)
+
+There is no live-screenshot tool. During the drive phase the agent clicks blind — it must
+already know coordinates from some other source. The first mislocated click derails the
+recording and the agent only finds out after `stop_recording` → `get_frames`.
+
+**Fix is nearly free:** `Session::screenshot()` **already exists** (used as the region-picker
+backdrop; it returns a base64 PNG data URL). Expose it:
+
+- protocol: `Screenshot { width: Option<u32> }` → `ControlResponse::Frames`-style single PNG
+- tool: `screenshot` — "See the current screen NOW (before/while recording) to locate what
+  to click."
+
+This is the highest-leverage 30 lines on this list. It turns "the agent needs a second
+computer-use tool to find coordinates" into a self-contained loop: screenshot → locate →
+click → screenshot → verify → next step.
+
+### 2.2 The agent is told to critique zooms but is never told where they are (P0)
+
+The `get_frames` tool description says *"sample sparsely, e.g. around each zoom"* — but
+`stop_recording` returns only a zoom **count**, and `clip_state`
+(`src-tauri/src/session.rs:836`) returns `{duration, zooms: usize, cuts, speed_regions}`.
+The agent has no way to know *when* the zooms happen or *where* they centre.
+
+**Fix:** return the segments. Extend `ClipInfo` (or the `RecordingSummary`) with:
+
+```rust
+pub struct ZoomSpan { pub start: f64, pub end: f64, pub amount: f64 }
+// plus cuts: Vec<(f64, f64)>, and output_duration (see 2.4)
+```
+
+Then the agent can deterministically sample `[start - 0.2, midpoint, end + 0.2]` per zoom
+instead of guessing timestamps across the whole clip. This also cuts vision-token cost —
+fewer wasted frames.
+
+### 2.3 The agent can't fix anything — its only tool is a full re-record (P0)
+
+`session.rs` already implements the entire edit surface the Tauri UI uses: delete/retime
+zoom keyframes, `add_cut`/`update_cut`/`delete_cut` (session.rs:1078+), `add_speed_region`,
+`auto_speed` (session.rs:964), `clear_speed`, trim. **None of it is exposed over the control
+protocol.** So when the critique finds "dead air from 4–7 s" or "the second zoom is
+mis-centred", the only remedy is re-driving the whole target app — the most expensive and
+least deterministic operation available.
+
+**Fix:** expose the existing ops (each is a ~5-line dispatch arm + protocol variant):
+
+| New op | Wraps | Critique it fixes |
+|---|---|---|
+| `list_zooms` / extended `clip_state` | project.zooms | (see 2.2) |
+| `remove_zoom { index }` | existing zoom CRUD | "zoom on a misclick / wrong target" |
+| `add_zoom { start, end, x, y, amount }` | existing zoom CRUD (Manual mode) | "this moment needed a zoom" |
+| `update_zoom { index, ... }` | existing zoom CRUD | "zoom leaves too early / wrong centre" |
+| `add_cut { start, end }` | `Session::add_cut` | "dead air / loading spinner" |
+| `auto_speed { factor }` | `Session::auto_speed` | "the idle stretches drag" |
+| `set_trim { start, end }` | existing trim | "trim the awkward first second" |
+
+This changes the iteration economics completely: re-record only when the *content* is wrong;
+repair timing/framing in place. It's also exactly the "bounded, convergent verify loop" the
+research doc calls for — edits are deterministic, re-records are not.
+
+### 2.4 `get_frames`/`seek` sample source time, but export runs on the output timeline (P1 correctness bug)
+
+- Export maps output→source through cuts + speed: `session.rs:565–585`
+  (`out_mapping` / `output_to_source`).
+- `sample_frames` (`session.rs:851,868`) and `seek` (`session.rs:476,482`) index frames by
+  **raw source time** with no remap, and `clip_info.duration` is the **source** duration.
+
+So as soon as the agent uses `set_paused` (paused spans become cuts at stop:
+`session.rs:431–447`) or any speed region exists, the timestamps the agent critiques do
+**not** correspond to the exported GIF's timeline — frames inside cuts are even sampleable
+though they'll never appear in the export. The critique loop is then judging footage that
+doesn't ship.
+
+**Fix:** make the control-facing sampling operate in **output time**: map each requested `t`
+through `output_to_source` (the code already exists for export), and report
+`output_duration` in `clip_state` alongside the source duration. That way `get_frames(t)`
+shows *exactly* what the exported GIF shows at `t`. (The editor UI can keep source-time
+seeking; this only needs to change in the control path or behind a flag.)
+
+### 2.5 No status / no cancel / no recovery (P1)
+
+If a tool call fails mid-flow (or the MCP client restarts), the agent has no way to ask
+"am I recording right now?" and no way to abandon a botched take other than `stop_recording`
+(which builds the full editable clip just to throw it away). Add:
+
+- `status` → `{ state: idle|recording|paused|clip_ready, elapsed_s, region, zoom_amount }`
+- `cancel_recording` → stop + discard without building the project.
+
+Cheap, and it makes the sidecar robust to the messy reality of agent sessions.
+
+### 2.6 `get_frames` has no default downscale (P2)
+
+`GetFrames.width` is optional and unset means full output resolution — a 2560-px-wide
+base64 PNG per sampled frame straight into the agent's context. Default to ~800 px in the
+MCP tool layer (agent can still ask for more) to protect context/token budgets. Also
+consider capping `times.len()` (e.g. 16) with a clear error, so a confused agent can't
+request 200 frames.
+
+---
+
+## Part 3 — Input injection correctness (works-on-my-machine bugs)
+
+### 3.1 `SendInput` failures are silently swallowed (P1)
+
+`inject.rs:128–131`: `let _sent = unsafe { SendInput(...) }`. If the target window is
+**elevated** (UIPI blocks injection from a non-elevated Vuoom), or input is otherwise
+rejected, every click/keystroke silently no-ops. The agent then records a demo of nothing
+happening and can't tell why.
+
+**Fix:** return the injected count, compare to `inputs.len()`, and propagate an error
+(`"input injection blocked — is the target app elevated?"`) through
+`ControlResponse::Error` so the agent sees it immediately. This also means the injection
+functions should return `Result`, and `control_server.rs` should map them with `unit()`
+like the stateful ops.
+
+### 3.2 Extended-key flag is missing (P1)
+
+`inject.rs:211` (`vk_event`) never sets `KEYEVENTF_EXTENDEDKEY`. Arrows, Home/End,
+PgUp/PgDn, Insert/Delete are *extended* keys; without the flag some apps (terminals,
+anything reading scan codes, RDP sessions, some games/Electron apps) will interpret them as
+numpad keys — e.g. "down arrow" becomes "numpad 2". Set the flag for the extended VK set.
+While in there, consider also sending real scan codes (`MapVirtualKeyW`) alongside VKs —
+some apps ignore VK-only injection.
+
+### 3.3 `key_to_vk` has no punctuation keys (P1)
+
+`inject.rs:51` covers modifiers, named keys, letters, digits, F1–F12 — but **no OEM keys**.
+Chords like `ctrl+=` / `ctrl+-` (zoom in every browser — practically the first thing a demo
+agent will try), `ctrl+/` (comment toggle), `ctrl+.` etc. return `unknown key`. Add the
+common `VK_OEM_*` mappings: `- = [ ] ; ' , . / \` `` ` ``.
+
+### 3.4 `type_text` and control characters (P2)
+
+`\n` typed as a Unicode code unit (0x0A) does not reliably activate default buttons or
+submit forms the way a real Enter press does; `\t` similarly won't move focus in many
+controls. Map `\n` → VK_RETURN press and `\t` → VK_TAB press inside `type_text`, unicode
+for everything else.
+
+### 3.5 Double-click nuance (P3, fine as-is)
+
+The down/up/down/up single batch registers as a double-click (same position, ~0 ms apart —
+within `GetDoubleClickTime`), so this works; once pacing (1.2) exists, keep the pair gap
+under ~100 ms deliberately. No action needed beyond not breaking it.
+
+---
+
+## Part 4 — Protocol & server robustness
+
+### 4.1 No authentication on the control server (P1, security)
+
+`control_server.rs:31` binds loopback and gates on the env var — good — but once enabled,
+**any local process** can read `%TEMP%\vuoom-control.json` and inject arbitrary input
+(keystrokes into whatever is focused!). Loopback is not a trust boundary on a multi-process
+machine, and this ships in a public repo advertising the port file location.
+
+**Fix (small):** generate a random token at startup, write it into the port file
+(`{"port": N, "token": "..."}`), require it — simplest form: first line of each connection
+must be the token or the server drops the socket. `discover_port` grows into
+`discover_endpoint() -> (port, token)`. ~40 lines total across the two crates.
+
+Related nits:
+- `VUOOM_ENABLE_CONTROL=0` currently **enables** the server (`control_server.rs:27` checks
+  presence, not value). Treat `0`/`false`/empty as off.
+- Delete the port file on graceful shutdown so a stale file doesn't point a future sidecar
+  at a dead (or worse, someone else's) port. Cheap partial: also write the PID and let the
+  sidecar sanity-check it.
+
+### 4.2 No timeouts anywhere on the wire (P1)
+
+`vuoom-control`'s `Client::call` (`lib.rs:337`) does a blocking `read_line` with **no read
+timeout**, and `connect` with no connect timeout. If Vuoom hangs (or a long export is in
+progress on the server side of the same pipeline), the MCP tool call hangs forever, which
+then wedges the agent's turn. Set `set_read_timeout` / `connect_timeout` — generous for
+export (minutes), short for everything else. Which leads to…
+
+### 4.3 Long exports block the whole bridge (P2)
+
+Two compounding designs:
+- `Bridge` (`vuoom-mcp/src/main.rs:38–60`) holds the connection `Mutex` across the entire
+  blocking call — so during a 90-second GIF export, even `ping` blocks.
+- `export_gif` in `dispatch` runs synchronously on the connection thread with a no-op
+  progress callback (`control_server.rs:185`).
+
+**Fix:** make export a job: `ExportGif` returns immediately with a job id;
+`export_status { id }` → `{ done, total, finished, error?, path }`. The session already
+threads a `progress(done, total)` callback through export — plumb it into a shared job
+table. The agent gets progress narration for free, and per-call timeouts (4.2) can stay
+short. (Alternative minimal fix: keep sync export but open a *dedicated* connection per
+tool call so `ping`/`status` never queue behind it.)
+
+### 4.4 `pending_auto_click` leaks into interactive recordings (P1, sneaky)
+
+`start_recording` (tool) sets `SetAutoZoomOnClick { on: true }` and the flag is **sticky**
+(`session.rs`, `pending_auto_click` applies to "the next recording"). Sequence: agent
+records a demo → human later hits record in the UI → their recording unexpectedly zooms on
+every click, because the agent's flag was never reset. Also, the tool's two-call sequence
+(`main.rs:290–295`) isn't atomic — if `StartRecording` fails, the flag is still flipped.
+
+**Fix:** carry the flag *in* `StartRecording { auto_zoom_on_click: Option<bool> }` instead
+of a separate sticky setter, or reset the pending flag to the config default inside
+`stop_recording`. One round-trip fewer, one race fewer, zero cross-contamination.
+
+### 4.5 `wait` is unclamped (P2)
+
+`main.rs:384` sleeps for any `ms` the model passes. A hallucinated `ms: 3600000` wedges the
+turn. Clamp to something sane (e.g. 15 000 ms) and say so in the description ("for longer
+waits, call wait repeatedly") — this also keeps each tool call within client timeouts.
+
+### 4.6 Concurrent clients can interleave stateful ops (P3)
+
+Each accepted connection gets its own thread (`control_server.rs:47`) and stateful ops have
+no cross-connection coordination — two sidecars could interleave `start/stop`. Given the
+opt-in, single-user posture this is acceptable; if you add the token (4.1), consider also
+accepting only one active control connection at a time. Document it either way.
+
+---
+
+## Part 5 — MCP-layer polish
+
+- **Tool annotations.** rmcp supports MCP tool annotations — mark `ping`, `screen_geometry`,
+  `clip_state`, `get_frames`, `estimate_gif` as `readOnlyHint`, and `export_*` /
+  input-injection tools as non-idempotent/destructive. Clients use these for permissions UX;
+  it's metadata you get almost for free.
+- **Structured errors.** Everything maps to `McpError::internal_error` (`main.rs:88–90`).
+  Distinguish at least "Vuoom not running / control disabled" (actionable: tell the user to
+  launch with `VUOOM_ENABLE_CONTROL=1`) from "bad request" from "op failed" — the agent
+  reacts very differently to each.
+- **`unexpected: {other:?}` responses** (e.g. `main.rs:250`) return success with a debug
+  string. Make protocol mismatches an *error* so the agent doesn't parse Rust debug output.
+- **Instructions string** (`main.rs:487`): after Part 1 lands, encode the winning recipe —
+  glide-then-click defaults, the rhythm guidance, the "tail wait ≥ 2.5 s before
+  stop_recording" rule, "sample frames only around zoom spans," "prefer edit ops over
+  re-recording," and the 3–4 iteration cap from the research doc. The instructions are the
+  cheapest place to raise output quality across every client.
+- **rmcp pin:** `rmcp = "1.7"` — pinned as the research doc recommended. Good; revisit at 2.0.
+
+---
+
+## Part 6 — Testing gaps
+
+Current tests (protocol round-trips, `normalize_abs`, `key_to_vk`, mock control server
+example) are solid for the pure layers. Missing:
+
+1. **Sidecar ↔ mock-server integration test in CI** — the `mock_server.rs` example exists
+   but nothing exercises `vuoom-mcp` against it automatically (tools/list is smoke-tested
+   locally per the docs; make it a real `#[test]` or CI step, including one full
+   tool-call round trip and the error path when the server is absent).
+2. **Humanizer unit tests** (once built): the path generator is pure math — assert monotone
+   progress, zero end velocity, duration scaling, and that the emitted event count matches
+   the sample rate.
+3. **Output-time mapping test** for 2.4: with one cut, assert `sample_frames(t)` equals the
+   frame `export` emits at `t`.
+4. **A scripted "golden demo"** (drive Notepad or the Vuoom window itself: click, type,
+   scroll, export) runnable on a real machine as the manual runtime checklist —
+   `docs/AI_DEMO_DIRECTOR.md` already lists what needs runtime verification; turn it into a
+   copy-pasteable script.
+
+---
+
+## Prioritized roadmap
+
+**P0 — makes recordings smooth and the loop functional (do these first):**
+1. Humanized cursor glide (`move_cursor_smooth`, glide-then-click default, distance-scaled
+   duration) — §1.1
+2. Paced typing (`cps` param) — §1.2
+3. `screenshot` tool (live perception; `Session::screenshot` already exists) — §2.1
+4. Zoom spans + cuts + output duration in `clip_state`/`stop_recording` — §2.2
+5. Edit ops over the protocol (remove/add/update zoom, add_cut, auto_speed, trim) — §2.3
+
+**P1 — correctness & robustness:**
+6. Stepped scroll + `drag` tool — §1.3, §1.4
+7. `SendInput` failure detection (UIPI) — §3.1
+8. `KEYEVENTF_EXTENDEDKEY` + OEM punctuation keys — §3.2, §3.3
+9. Output-time frame sampling — §2.4
+10. `status` + `cancel_recording` — §2.5
+11. Auth token in port file; honor `VUOOM_ENABLE_CONTROL=0`; stale-file cleanup — §4.1
+12. Client read/connect timeouts — §4.2
+13. Fix `pending_auto_click` stickiness (flag inside `StartRecording`) — §4.4
+
+**P2 — polish:**
+14. Async export job + progress — §4.3
+15. `get_frames` default width + count cap — §2.6
+16. `wait` clamp — §4.5
+17. `set_zoom_style` op; rhythm recipe in INSTRUCTIONS; tool annotations; structured
+    errors — §1.5, §1.6, Part 5
+18. Sidecar↔mock CI integration test + golden demo script — Part 6
+
+**v2 — the endgame for "perfect":**
+19. Synthetic cursor rendering (capture without cursor, draw smoothed cursor in the
+    compositor, scale it under zoom) — §1.1. This is the Screen-Studio-grade cursor and it
+    improves *human* recordings too.
+
+---
+
+## What you did right (keep these)
+
+- The sidecar/protocol/in-app split with a dependency-light contract crate and round-trip
+  tests — textbook.
+- Injected input flowing through the real low-level hook so one mechanism drives the app
+  *and* the zoom planner — the elegant core insight, verified in code.
+- Opt-in env gate + loopback bind for an input-injection surface (just add the token).
+- Deterministic camera track shared by scrub/export; critically-damped springs with exact
+  integration (no overshoot) — the zoom *math* is not your problem; the *inputs* to it are.
+- Honest docs: the research file's risk table ("desktop driving 8/10, sync 8/10") is exactly
+  where the runtime issues live. The docs predicted the pain points; Part 1–2 above is how
+  to pay them down.

--- a/mcp_improve.md
+++ b/mcp_improve.md
@@ -1,5 +1,13 @@
 # MCP / AI Demo Director — Code Review & Improvement Plan
 
+> **Implementation status (2026-07-02):** everything below through P2 is now implemented on
+> this branch — the humanizer (§1.1–1.4), perception + repair loop (§2.1–2.6), injection
+> correctness (§3.1–3.4), server hardening (§4.1–4.5), and the MCP-layer polish + tests
+> (Parts 5–6). Still open: the §1.5 server-side `min_action_gap_ms` (the rhythm recipe went
+> into the MCP instructions instead), §4.6 single-connection enforcement (documented,
+> accepted), and the **v2 synthetic cursor rendering** (§1.1 endgame + roadmap item 19).
+> All of it needs the runtime pass described in `docs/IMPLEMENTATION-STATUS.md`.
+
 **Branch reviewed:** `feat/ai-demo-director-mcp` (13 commits over `main`)
 **Files reviewed:** `crates/vuoom-mcp`, `crates/vuoom-control`, `crates/vuoom-input/src/inject.rs`,
 `src-tauri/src/control_server.rs`, the `session.rs` additions, and the zoom pipeline

--- a/mcp_v2_implementation.md
+++ b/mcp_v2_implementation.md
@@ -1,0 +1,111 @@
+# AI Demo Director v2 — Implementation Summary
+
+**Branch:** `feat/ai-demo-director-mcp` (PR #1) · **Date:** 2026-07-02 · **CI:** ✅ green
+(rustfmt, clippy `-D warnings`, all tests, full workspace check)
+
+This implements the complete improvement plan from [`mcp_improve.md`](mcp_improve.md) —
+the review that found why agent recordings looked robotic and why the critique loop was
+half-blind. Four commits, each pushed green.
+
+---
+
+## Commit 1 — Rebase onto latest main (`266c517`)
+
+Picked up ~20 new main commits (v0.1.28–v0.1.30: streaming GIF encoder, binary-search
+frame lookup, poison-resilient locks, UI fixes). The textual merge missed **two semantic
+conflicts** that had to be fixed by hand:
+
+- main's locks became poison-resilient (`.lock().unwrap_or_else(|e| e.into_inner())`) —
+  the branch's control code still used `map_err(|_| "lock poisoned")?`
+- `nearest_idx` now takes `store.recs()` (a `&[FrameRec]`), not the store itself
+
+`Cargo.lock` was regenerated minimally via `cargo metadata` (no full re-resolution).
+
+> Lesson for future rebases of this branch: those two patterns are invisible to git's
+> merge — always grep for them after rebasing.
+
+## Commit 2 — The humanizer (`4e8d2ee`) — *cursor flow fully smooth*
+
+The root cause of "robotic" recordings: the hardware cursor is baked into the captured
+pixels (WGC draws it), and every injected action warped it instantly. Fixed at the
+source, in `crates/vuoom-input/src/inject.rs`:
+
+| Before | Now |
+|---|---|
+| Click teleports the cursor in one `SendInput` batch | **Minimum-jerk glide** (`10p³−15p⁴+6p⁵`, zero end velocity/acceleration) at ~125 Hz, duration scaled to distance (`clamp(150 + px/3, 200, 900)` ms) → settle ~120 ms → press 60 ms → release |
+| Whole string typed in ~0 ms | **Paced typing** ~15 cps (0.5–200 configurable) with deterministic per-char jitter; `\n`/`\t` press real Enter/Tab |
+| Scroll = one violent jump | **One notch per 40 ms step** so smooth-scrolling apps animate |
+| No drag at all | **`drag`**: glide → hold → eased path → release (sliders, drag-drop, selection) |
+| `SendInput` failures swallowed | Short count → `Err` ("is the target app running elevated?") — UIPI can no longer produce a demo of nothing happening |
+| Arrows read as numpad keys in scan-code apps | `KEYEVENTF_EXTENDEDKEY` for the nav cluster |
+| No punctuation chords | OEM keys in `key_to_vk`: `- = [ ] ; ' , . / \ ` `` → `ctrl+=` browser zoom works |
+
+Double win: the glide streams **real move events through the low-level hook**, so the
+auto-zoom camera follows a smooth path instead of a step function — cursor AND camera
+smoothness had the same root cause. All pure math (`min_jerk`, `glide_points`,
+`glide_duration_ms`, `jitter_factor`, `is_extended_vk`) is unit-tested.
+
+## Commit 3 — Protocol v2 across the stack (`66b0992`) — *the loop can see and repair*
+
+**Perception** (the agent was driving blind):
+- `screenshot` — live PNG of the recording monitor, any time (reuses
+  `Session::screenshot`'s capture path, downscalable)
+- `clip_state` now returns the actual **zoom/cut/speed spans** (`{start, end, amount,
+  focus}`) plus `output_duration` — not bare counts, so the agent knows exactly where to
+  sample and which index to repair
+- `get_frames` / `seek` sample the **output timeline**, mapped through trim + cuts +
+  speed via the same `out_mapping`/`output_to_source` path export uses — the agent
+  critiques *exactly what ships*
+
+**Repair** (before: the only fix was a full re-record):
+- `add_zoom` / `update_zoom` / `set_zoom_focus` / `remove_zoom`
+- `add_cut` / `update_cut` / `remove_cut`
+- `auto_speed` / `clear_speed` / `set_trim`
+- `set_zoom_style` (hold, pre-roll, spring half-lives — per-recording)
+- `status` (`idle|recording|paused|clip_ready` + elapsed) and `cancel_recording`
+
+**Hardening:**
+- **Auth token**: random 128-bit token in `%TEMP%\vuoom-control.json`, required as the
+  first line of every connection — loopback is not a trust boundary for input injection
+- Client **connect (3 s) / read (120 s) timeouts** — a hung server can't wedge the agent
+- **Exports are jobs**: `export_gif`/`export_mp4` return an id immediately;
+  `export_status` polls `{done, total, finished, error, path}`
+- `VUOOM_ENABLE_CONTROL=0`/`false`/`off` now actually disables; discovery file deleted
+  on app exit (`RunEvent::Exit`)
+- Agent-scoped flags (`auto_zoom_on_click`, zoom style) **reset at stop/cancel/failed
+  start** — an agent take can never change how your next interactive recording behaves
+
+**MCP sidecar polish:** 35 tools total; `get_frames` capped at 16 frames with an 800 px
+default width (protects the agent's context); `wait` clamped to 15 s; protocol-shape
+mismatches are errors instead of parseable-looking text; the connect instructions teach
+the full rhythm — *see → drive → settle 800–1500 ms → tail-wait 2500 ms → critique →
+repair → export, cap at 3–4 takes*.
+
+## Commit 4 — Tests + docs (`5c0dca3`)
+
+- `vuoom-control/tests/client_auth.rs` — authenticated round trip works; wrong token is
+  dropped with a clear "closed the connection" error
+- `vuoom-mcp` router smoke test — asserts all 35 director tools are registered (the
+  `#[tool_handler]` macro wiring is otherwise invisible until an agent connects)
+- Protocol round-trip tests extended to every new variant + optional-field defaults
+- Mock server upgraded to protocol v2 (token handshake + all ops)
+- `docs/AI_DEMO_DIRECTOR.md` rewritten; `docs/IMPLEMENTATION-STATUS.md` gained the v2
+  table; `mcp_improve.md` marked implemented
+
+---
+
+## What's still open
+
+1. **Runtime pass on the real machine** (CI is headless — SendInput/GPU can't run there):
+   ```powershell
+   cargo build --release -p vuoom-mcp
+   $env:VUOOM_ENABLE_CONTROL = "1"; .\Vuoom.exe   # or pnpm tauri dev
+   ```
+   then let an agent drive a full take and check: cursor glides (no teleport), typing
+   pace, zoom centring, `get_frames` matching the export, export job completing.
+2. **v2 endgame — synthetic cursor rendering** (`mcp_improve.md` §1.1 / roadmap 19):
+   capture with `CursorCaptureSettings::WithoutCursor` and draw a smoothed cursor in the
+   compositor. Decouples the pointer from OS jitter entirely, allows cursor scaling under
+   zoom, and improves *human* recordings too. The Screen-Studio-grade final polish.
+3. Two consciously skipped items: server-side `min_action_gap_ms` (rhythm lives in the
+   MCP instructions instead) and single-connection enforcement (documented, accepted).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ vuoom-input.workspace = true
 vuoom-capture.workspace = true
 vuoom-render.workspace = true
 vuoom-preview.workspace = true
+vuoom-control.workspace = true
 
 # Win32 helpers: SetWindowDisplayAffinity (exclude overlays from screen capture),
 # CF_HDROP clipboard file copy, hotkey polling. Match the version vuoom-input /

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -435,7 +435,9 @@ pub async fn add_zoom(
     engine: tauri::State<'_, Engine>,
     t: f64,
 ) -> Result<Vec<ZoomKeyframe>, String> {
-    engine.session()?.add_zoom(t)
+    // The editor UI adds cursor-following segments with default spring feel; the AI Demo
+    // Director's rect/half-life overrides come in through the control server, not here.
+    engine.session()?.add_zoom(t, None, None, None)
 }
 
 /// Retime / re-level the zoom segment at `index`; returns the updated segment list.
@@ -447,7 +449,9 @@ pub async fn update_zoom(
     end: f64,
     amount: f64,
 ) -> Result<Vec<ZoomKeyframe>, String> {
-    engine.session()?.update_zoom(index, start, end, amount)
+    engine
+        .session()?
+        .update_zoom(index, start, end, amount, None, None)
 }
 
 /// Set a zoom segment's focus: pass `x` + `y` (normalized) to hold a fixed point, or
@@ -463,7 +467,7 @@ pub async fn set_zoom_focus(
         (Some(x), Some(y)) => Some((x, y)),
         _ => None,
     };
-    engine.session()?.set_zoom_focus(index, focus)
+    engine.session()?.set_zoom_focus(index, focus, None)
 }
 
 /// Delete the zoom segment at `index`; returns the updated segment list.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -359,7 +359,8 @@ pub fn auto_speed(
     engine: tauri::State<'_, Engine>,
     factor: f64,
 ) -> Result<Vec<SpeedRegion>, String> {
-    engine.session()?.auto_speed(factor)
+    // The interactive editor uses the default idle-gap/lead/tail thresholds.
+    engine.session()?.auto_speed(factor, None, None, None)
 }
 
 /// Remove all speed regions.

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -1,0 +1,202 @@
+//! Localhost control server — the in-app half of the AI Demo Director.
+//!
+//! When enabled, Vuoom binds a `127.0.0.1` TCP port and answers newline-delimited
+//! [`vuoom_control`] requests: set region, start/stop recording, inject mouse/keyboard,
+//! sample frames for the agent to *see*, and export. The standalone `vuoom-mcp` sidecar
+//! connects here on behalf of an AI agent (Claude). See `docs/13-AI-Demo-Director-Research.md`.
+//!
+//! **Safety:** the server can inject real input, so it is **opt-in** — it only starts when the
+//! `VUOOM_ENABLE_CONTROL` environment variable is set, and it binds loopback only.
+
+use crate::Engine;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use tauri::{AppHandle, Manager};
+use vuoom_capture::CropRegion;
+use vuoom_control::{
+    write_message, Button, ControlRequest, ControlResponse, RecordingSummary, ScreenGeometry,
+};
+use vuoom_input::InjectButton;
+
+/// Set this env var (to any value) to enable the control server. Off by default because it
+/// can drive real mouse/keyboard input.
+const ENABLE_VAR: &str = "VUOOM_ENABLE_CONTROL";
+
+/// Start the control server on a background thread, if enabled. No-op otherwise.
+pub fn start(app: AppHandle) {
+    if std::env::var(ENABLE_VAR).is_err() {
+        return;
+    }
+    std::thread::spawn(move || {
+        let listener = match TcpListener::bind(("127.0.0.1", 0)) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("vuoom control server: bind failed: {e}");
+                return;
+            }
+        };
+        let port = listener.local_addr().map_or(0, |a| a.port());
+        if let Err(e) = vuoom_control::write_port_file(port) {
+            eprintln!("vuoom control server: port file write failed: {e}");
+        }
+        eprintln!("vuoom control server: listening on 127.0.0.1:{port}");
+        for stream in listener.incoming() {
+            match stream {
+                Ok(s) => {
+                    let app = app.clone();
+                    std::thread::spawn(move || serve(&app, s));
+                }
+                Err(e) => eprintln!("vuoom control server: accept failed: {e}"),
+            }
+        }
+    });
+}
+
+/// Serve one client connection: read requests line-by-line, dispatch, write replies.
+fn serve(app: &AppHandle, stream: TcpStream) {
+    let Ok(mut writer) = stream.try_clone() else {
+        return;
+    };
+    let reader = BufReader::new(stream);
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let resp = match serde_json::from_str::<ControlRequest>(&line) {
+            Ok(req) => dispatch(app, req),
+            Err(e) => ControlResponse::error(format!("bad request: {e}")),
+        };
+        if write_message(&mut writer, &resp).is_err() {
+            break;
+        }
+    }
+}
+
+/// Map a protocol [`Button`] to the injection [`InjectButton`].
+fn map_button(b: Button) -> InjectButton {
+    match b {
+        Button::Left => InjectButton::Left,
+        Button::Right => InjectButton::Right,
+        Button::Middle => InjectButton::Middle,
+    }
+}
+
+/// Wrap a `Result<(), String>` as an [`ControlResponse`].
+fn unit(r: Result<(), String>) -> ControlResponse {
+    match r {
+        Ok(()) => ControlResponse::Ok,
+        Err(e) => ControlResponse::error(e),
+    }
+}
+
+/// Turn one request into a response, calling into injection (no engine needed) or the
+/// recording/edit/export [`Engine`] session.
+fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
+    // Stateless ops: liveness, geometry, and input injection don't need the engine.
+    match &req {
+        ControlRequest::Ping => return ControlResponse::Ok,
+        ControlRequest::ScreenGeometry => {
+            let (x, y, width, height) = vuoom_input::virtual_screen();
+            return ControlResponse::Geometry(ScreenGeometry {
+                x,
+                y,
+                width,
+                height,
+            });
+        }
+        ControlRequest::MoveCursor { x, y } => {
+            vuoom_input::move_cursor(*x, *y);
+            return ControlResponse::Ok;
+        }
+        ControlRequest::Click {
+            x,
+            y,
+            button,
+            double,
+        } => {
+            vuoom_input::click(*x, *y, map_button(*button), *double);
+            return ControlResponse::Ok;
+        }
+        ControlRequest::TypeText { text } => {
+            vuoom_input::type_text(text);
+            return ControlResponse::Ok;
+        }
+        ControlRequest::Scroll { x, y, delta } => {
+            vuoom_input::scroll(*x, *y, *delta);
+            return ControlResponse::Ok;
+        }
+        ControlRequest::KeyChord { keys } => {
+            let mut vks = Vec::with_capacity(keys.len());
+            for k in keys {
+                match vuoom_input::key_to_vk(k) {
+                    Some(vk) => vks.push(vk),
+                    None => return ControlResponse::error(format!("unknown key: {k}")),
+                }
+            }
+            vuoom_input::key_chord(&vks);
+            return ControlResponse::Ok;
+        }
+        _ => {}
+    }
+
+    // Stateful ops need the booted session.
+    let engine = app.state::<Engine>();
+    let session = match engine.session() {
+        Ok(s) => s,
+        Err(e) => return ControlResponse::error(e),
+    };
+    match req {
+        ControlRequest::SetRegion { x, y, w, h } => {
+            let region = match (x, y, w, h) {
+                (Some(x), Some(y), Some(w), Some(h)) if w > 0 && h > 0 => {
+                    Some(CropRegion { x, y, w, h })
+                }
+                _ => None,
+            };
+            unit(session.set_region(region))
+        }
+        ControlRequest::SetZoomAmount { amount } => unit(session.set_zoom_amount(amount)),
+        ControlRequest::StartRecording => unit(session.start_recording()),
+        ControlRequest::StopRecording => match session.stop_recording() {
+            Ok(s) => ControlResponse::Recording(RecordingSummary {
+                duration: s.duration,
+                frames: s.frames,
+                zooms: s.zooms,
+            }),
+            Err(e) => ControlResponse::error(e),
+        },
+        ControlRequest::SetPaused { paused } => unit(session.set_record_paused(paused)),
+        ControlRequest::Seek { t } => unit(session.seek(t)),
+        ControlRequest::ClipState => match session.clip_info() {
+            Ok(c) => ControlResponse::Clip(c),
+            Err(e) => ControlResponse::error(e),
+        },
+        ControlRequest::GetFrames { times, width } => match session.sample_frames(&times, width) {
+            Ok(frames) => ControlResponse::Frames { frames },
+            Err(e) => ControlResponse::error(e),
+        },
+        ControlRequest::ExportGif {
+            path,
+            fps,
+            width,
+            quality,
+        } => unit(session.export_gif(path, fps, width, quality, &|_, _| {})),
+        ControlRequest::ExportMp4 {
+            path,
+            fps,
+            width,
+            quality,
+        } => unit(session.export_mp4(path, fps, width, quality, &|_, _| {})),
+        ControlRequest::EstimateGif {
+            fps,
+            width,
+            quality,
+        } => match session.estimate_gif(fps, width, quality) {
+            Ok(bytes) => ControlResponse::Size { bytes },
+            Err(e) => ControlResponse::error(e),
+        },
+        // Ping + injection + geometry already handled above.
+        _ => ControlResponse::error("unhandled request"),
+    }
+}

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -23,7 +23,7 @@ use tauri::{AppHandle, Manager};
 use vuoom_capture::CropRegion;
 use vuoom_control::{
     write_message, Button, ControlRequest, ControlResponse, ExportState, RecordingSummary,
-    ScreenGeometry,
+    RegionRect, ScreenGeometry, WindowRect,
 };
 use vuoom_input::InjectButton;
 
@@ -317,6 +317,19 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             return unit(vuoom_input::key_chord(&vks));
         }
         ControlRequest::ExportStatus { id } => return export_status(*id),
+        ControlRequest::ListWindows => {
+            let windows = vuoom_capture::list_windows()
+                .into_iter()
+                .map(|w| WindowRect {
+                    title: w.title,
+                    x: w.x,
+                    y: w.y,
+                    w: w.w,
+                    h: w.h,
+                })
+                .collect();
+            return ControlResponse::Windows { windows };
+        }
         _ => {}
     }
 
@@ -458,7 +471,12 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
         ControlRequest::RemoveCut { index } => {
             cuts_after(session, session.delete_cut(index).map(|_| ()))
         }
-        ControlRequest::AutoSpeed { factor } => match session.auto_speed(factor) {
+        ControlRequest::AutoSpeed {
+            factor,
+            min_gap,
+            lead,
+            tail,
+        } => match session.auto_speed(factor, min_gap, lead, tail) {
             Ok(_) => match session.clip_info() {
                 Ok(c) => ControlResponse::Speeds { speeds: c.speeds },
                 Err(e) => ControlResponse::error(e),
@@ -487,9 +505,62 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             Ok(bytes) => ControlResponse::Size { bytes },
             Err(e) => ControlResponse::error(e),
         },
-        // Ping + injection + geometry + export status already handled above.
+        ControlRequest::PreviewClip {
+            start,
+            end,
+            fps,
+            width,
+        } => match session.preview_clip(start, end, fps, width) {
+            Ok(info) => ControlResponse::Preview(info),
+            Err(e) => ControlResponse::error(e),
+        },
+        ControlRequest::SetRegionToWindow { title, padding } => {
+            match resolve_window_region(&title, padding) {
+                Ok((x, y, w, h)) => match session.set_region(Some(CropRegion { x, y, w, h })) {
+                    Ok(()) => ControlResponse::Region(RegionRect { x, y, w, h }),
+                    Err(e) => ControlResponse::error(e),
+                },
+                Err(e) => ControlResponse::error(e),
+            }
+        }
+        // Ping + injection + geometry + export status + list_windows already handled above.
         _ => ControlResponse::error("unhandled request"),
     }
+}
+
+/// Resolve a window title to a clamped capture rect (physical px): find the best window
+/// match, expand by `padding` (clamped 0–200), and clamp to the virtual screen. `CropRegion`
+/// is unsigned, so the origin floors at 0 (a window on a monitor left of the primary can't
+/// be region-snapped — a limitation shared with the plain `set_region` path).
+fn resolve_window_region(
+    title: &str,
+    padding: Option<i32>,
+) -> Result<(u32, u32, u32, u32), String> {
+    let win = vuoom_capture::find_window_bounds(title).ok_or_else(|| {
+        format!(
+            "no visible window matches \"{title}\" — pass a case-insensitive substring of the \
+             exact title and make sure the window isn't minimized"
+        )
+    })?;
+    let pad = i64::from(padding.unwrap_or(0).clamp(0, 200));
+    let left = i64::from(win.x) - pad;
+    let top = i64::from(win.y) - pad;
+    let right = i64::from(win.x) + i64::from(win.w) + pad;
+    let bottom = i64::from(win.y) + i64::from(win.h) + pad;
+
+    let (vx, vy, vw, vh) = vuoom_input::virtual_screen();
+    let vs_left = i64::from(vx).max(0);
+    let vs_top = i64::from(vy).max(0);
+    let vs_right = i64::from(vx) + i64::from(vw);
+    let vs_bottom = i64::from(vy) + i64::from(vh);
+
+    let left = left.clamp(vs_left, vs_right);
+    let top = top.clamp(vs_top, vs_bottom);
+    let right = right.clamp(left, vs_right);
+    let bottom = bottom.clamp(top, vs_bottom);
+    let w = (right - left).max(1) as u32;
+    let h = (bottom - top).max(1) as u32;
+    Ok((left as u32, top as u32, w, h))
 }
 
 /// After a zoom edit, answer with the updated zoom spans (or the edit's error).

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -9,7 +9,7 @@
 //! `VUOOM_ENABLE_CONTROL` environment variable is set, and it binds loopback only.
 
 use crate::Engine;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
 use tauri::{AppHandle, Manager};
 use vuoom_capture::CropRegion;

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -106,8 +106,7 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             });
         }
         ControlRequest::MoveCursor { x, y } => {
-            vuoom_input::move_cursor(*x, *y);
-            return ControlResponse::Ok;
+            return unit(vuoom_input::move_cursor_smooth(*x, *y, None));
         }
         ControlRequest::Click {
             x,
@@ -115,16 +114,19 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             button,
             double,
         } => {
-            vuoom_input::click(*x, *y, map_button(*button), *double);
-            return ControlResponse::Ok;
+            return unit(vuoom_input::click(
+                *x,
+                *y,
+                map_button(*button),
+                *double,
+                None,
+            ));
         }
         ControlRequest::TypeText { text } => {
-            vuoom_input::type_text(text);
-            return ControlResponse::Ok;
+            return unit(vuoom_input::type_text(text, None));
         }
         ControlRequest::Scroll { x, y, delta } => {
-            vuoom_input::scroll(*x, *y, *delta);
-            return ControlResponse::Ok;
+            return unit(vuoom_input::scroll(*x, *y, *delta, None));
         }
         ControlRequest::KeyChord { keys } => {
             let mut vks = Vec::with_capacity(keys.len());
@@ -134,8 +136,7 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
                     None => return ControlResponse::error(format!("unknown key: {k}")),
                 }
             }
-            vuoom_input::key_chord(&vks);
-            return ControlResponse::Ok;
+            return unit(vuoom_input::key_chord(&vks));
         }
         _ => {}
     }

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -157,6 +157,7 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             unit(session.set_region(region))
         }
         ControlRequest::SetZoomAmount { amount } => unit(session.set_zoom_amount(amount)),
+        ControlRequest::SetAutoZoomOnClick { on } => unit(session.set_auto_zoom_on_click(on)),
         ControlRequest::StartRecording => unit(session.start_recording()),
         ControlRequest::StopRecording => match session.stop_recording() {
             Ok(s) => ControlResponse::Recording(RecordingSummary {

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -2,29 +2,53 @@
 //!
 //! When enabled, Vuoom binds a `127.0.0.1` TCP port and answers newline-delimited
 //! [`vuoom_control`] requests: set region, start/stop recording, inject mouse/keyboard,
-//! sample frames for the agent to *see*, and export. The standalone `vuoom-mcp` sidecar
-//! connects here on behalf of an AI agent (Claude). See `docs/13-AI-Demo-Director-Research.md`.
+//! sample frames for the agent to *see*, edit the clip, and export. The standalone
+//! `vuoom-mcp` sidecar connects here on behalf of an AI agent (Claude).
+//! See `docs/13-AI-Demo-Director-Research.md`.
 //!
-//! **Safety:** the server can inject real input, so it is **opt-in** — it only starts when the
-//! `VUOOM_ENABLE_CONTROL` environment variable is set, and it binds loopback only.
+//! **Safety:** the server can inject real input, so it is **opt-in** — it only starts when
+//! the `VUOOM_ENABLE_CONTROL` environment variable is set to a truthy value, it binds
+//! loopback only, and every connection must present the random auth token from the
+//! discovery file as its first line (loopback alone is not a trust boundary: any local
+//! process could otherwise type into whatever window is focused).
 
+use crate::session::ZoomStyle;
 use crate::Engine;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Manager};
 use vuoom_capture::CropRegion;
 use vuoom_control::{
-    write_message, Button, ControlRequest, ControlResponse, RecordingSummary, ScreenGeometry,
+    write_message, Button, ControlRequest, ControlResponse, ExportState, RecordingSummary,
+    ScreenGeometry,
 };
 use vuoom_input::InjectButton;
 
-/// Set this env var (to any value) to enable the control server. Off by default because it
-/// can drive real mouse/keyboard input.
+/// Set this env var to enable the control server (`0`/`false`/`off`/empty stay disabled).
+/// Off by default because it can drive real mouse/keyboard input.
 const ENABLE_VAR: &str = "VUOOM_ENABLE_CONTROL";
+
+/// Whether this process wrote the discovery file (so shutdown cleanup never deletes a
+/// file that belongs to another Vuoom instance).
+static WROTE_PORT_FILE: AtomicBool = AtomicBool::new(false);
+
+/// Whether the enable var is set to something truthy.
+fn enabled() -> bool {
+    match std::env::var(ENABLE_VAR) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "off"
+        ),
+        Err(_) => false,
+    }
+}
 
 /// Start the control server on a background thread, if enabled. No-op otherwise.
 pub fn start(app: AppHandle) {
-    if std::env::var(ENABLE_VAR).is_err() {
+    if !enabled() {
         return;
     }
     std::thread::spawn(move || {
@@ -36,15 +60,19 @@ pub fn start(app: AppHandle) {
             }
         };
         let port = listener.local_addr().map_or(0, |a| a.port());
-        if let Err(e) = vuoom_control::write_port_file(port) {
-            eprintln!("vuoom control server: port file write failed: {e}");
+        let token = vuoom_control::generate_token();
+        match vuoom_control::write_port_file(port, &token) {
+            Ok(()) => WROTE_PORT_FILE.store(true, Ordering::Relaxed),
+            Err(e) => eprintln!("vuoom control server: port file write failed: {e}"),
         }
         eprintln!("vuoom control server: listening on 127.0.0.1:{port}");
+        let token = Arc::new(token);
         for stream in listener.incoming() {
             match stream {
                 Ok(s) => {
                     let app = app.clone();
-                    std::thread::spawn(move || serve(&app, s));
+                    let token = Arc::clone(&token);
+                    std::thread::spawn(move || serve(&app, s, &token));
                 }
                 Err(e) => eprintln!("vuoom control server: accept failed: {e}"),
             }
@@ -52,12 +80,28 @@ pub fn start(app: AppHandle) {
     });
 }
 
-/// Serve one client connection: read requests line-by-line, dispatch, write replies.
-fn serve(app: &AppHandle, stream: TcpStream) {
+/// Delete the discovery file on app shutdown (only if this process wrote it), so a stale
+/// endpoint never points a future sidecar at a dead — or someone else's — port.
+pub fn cleanup() {
+    if WROTE_PORT_FILE.load(Ordering::Relaxed) {
+        vuoom_control::remove_port_file();
+    }
+}
+
+/// Serve one client connection: authenticate, then read requests line-by-line, dispatch,
+/// write replies.
+fn serve(app: &AppHandle, stream: TcpStream, token: &str) {
     let Ok(mut writer) = stream.try_clone() else {
         return;
     };
-    let reader = BufReader::new(stream);
+    let mut reader = BufReader::new(stream);
+    // The first line must be the auth token from the discovery file; drop the connection
+    // otherwise (no reply — an unauthenticated peer learns nothing).
+    let mut auth = String::new();
+    if reader.read_line(&mut auth).is_err() || auth.trim() != token {
+        eprintln!("vuoom control server: rejected connection (bad auth token)");
+        return;
+    }
     for line in reader.lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
@@ -90,8 +134,96 @@ fn unit(r: Result<(), String>) -> ControlResponse {
     }
 }
 
+// ── Export jobs ─────────────────────────────────────────────────────────────────────
+//
+// Exports take minutes; running them inline would block the connection (and the agent's
+// tool call) past any sane timeout. Instead `ExportGif`/`ExportMp4` return a job id
+// immediately and the encode runs on its own thread, publishing progress the agent polls
+// with `ExportStatus`.
+
+/// Progress/result of one export job, shared with its worker thread.
+struct ExportJob {
+    done: AtomicU64,
+    total: AtomicU64,
+    finished: AtomicBool,
+    error: Mutex<Option<String>>,
+    path: String,
+}
+
+fn jobs() -> &'static Mutex<HashMap<u64, Arc<ExportJob>>> {
+    static JOBS: OnceLock<Mutex<HashMap<u64, Arc<ExportJob>>>> = OnceLock::new();
+    JOBS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Which container an export job writes.
+#[derive(Clone, Copy)]
+enum ExportKind {
+    Gif,
+    Mp4,
+}
+
+/// Spawn an export worker and hand back its job id.
+fn start_export(
+    app: &AppHandle,
+    kind: ExportKind,
+    path: String,
+    fps: u32,
+    width: Option<u32>,
+    quality: u8,
+) -> ControlResponse {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let job = Arc::new(ExportJob {
+        done: AtomicU64::new(0),
+        total: AtomicU64::new(0),
+        finished: AtomicBool::new(false),
+        error: Mutex::new(None),
+        path: path.clone(),
+    });
+    jobs()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(id, Arc::clone(&job));
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let result = (|| -> Result<(), String> {
+            let engine = app.state::<Engine>();
+            let session = engine.session()?;
+            let progress = |done: u32, total: u32| {
+                job.done.store(u64::from(done), Ordering::Relaxed);
+                job.total.store(u64::from(total), Ordering::Relaxed);
+            };
+            match kind {
+                ExportKind::Gif => session.export_gif(path, fps, width, quality, &progress),
+                ExportKind::Mp4 => session.export_mp4(path, fps, width, quality, &progress),
+            }
+        })();
+        if let Err(e) = result {
+            *job.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(e);
+        }
+        job.finished.store(true, Ordering::Relaxed);
+    });
+    ControlResponse::Job { id }
+}
+
+/// Snapshot an export job for `ExportStatus`.
+fn export_status(id: u64) -> ControlResponse {
+    let jobs = jobs().lock().unwrap_or_else(|e| e.into_inner());
+    match jobs.get(&id) {
+        Some(j) => ControlResponse::Export(ExportState {
+            done: j.done.load(Ordering::Relaxed),
+            total: j.total.load(Ordering::Relaxed),
+            finished: j.finished.load(Ordering::Relaxed),
+            error: j.error.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+            path: j.path.clone(),
+        }),
+        None => ControlResponse::error(format!("no such export job: {id}")),
+    }
+}
+
 /// Turn one request into a response, calling into injection (no engine needed) or the
 /// recording/edit/export [`Engine`] session.
+#[allow(clippy::too_many_lines)]
 fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
     // Stateless ops: liveness, geometry, and input injection don't need the engine.
     match &req {
@@ -105,28 +237,51 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
                 height,
             });
         }
-        ControlRequest::MoveCursor { x, y } => {
-            return unit(vuoom_input::move_cursor_smooth(*x, *y, None));
+        ControlRequest::MoveCursor { x, y, duration_ms } => {
+            return unit(vuoom_input::move_cursor_smooth(*x, *y, *duration_ms));
         }
         ControlRequest::Click {
             x,
             y,
             button,
             double,
+            glide_ms,
         } => {
             return unit(vuoom_input::click(
                 *x,
                 *y,
                 map_button(*button),
                 *double,
-                None,
+                *glide_ms,
             ));
         }
-        ControlRequest::TypeText { text } => {
-            return unit(vuoom_input::type_text(text, None));
+        ControlRequest::Drag {
+            x1,
+            y1,
+            x2,
+            y2,
+            button,
+            duration_ms,
+        } => {
+            return unit(vuoom_input::drag(
+                *x1,
+                *y1,
+                *x2,
+                *y2,
+                map_button(*button),
+                *duration_ms,
+            ));
         }
-        ControlRequest::Scroll { x, y, delta } => {
-            return unit(vuoom_input::scroll(*x, *y, *delta, None));
+        ControlRequest::TypeText { text, cps } => {
+            return unit(vuoom_input::type_text(text, *cps));
+        }
+        ControlRequest::Scroll {
+            x,
+            y,
+            delta,
+            step_ms,
+        } => {
+            return unit(vuoom_input::scroll(*x, *y, *delta, *step_ms));
         }
         ControlRequest::KeyChord { keys } => {
             let mut vks = Vec::with_capacity(keys.len());
@@ -138,6 +293,7 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             }
             return unit(vuoom_input::key_chord(&vks));
         }
+        ControlRequest::ExportStatus { id } => return export_status(*id),
         _ => {}
     }
 
@@ -148,6 +304,10 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
         Err(e) => return ControlResponse::error(e),
     };
     match req {
+        ControlRequest::Screenshot { width } => match session.screenshot_shot(width) {
+            Ok(shot) => ControlResponse::Shot(shot),
+            Err(e) => ControlResponse::error(e),
+        },
         ControlRequest::SetRegion { x, y, w, h } => {
             let region = match (x, y, w, h) {
                 (Some(x), Some(y), Some(w), Some(h)) if w > 0 && h > 0 => {
@@ -158,8 +318,32 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             unit(session.set_region(region))
         }
         ControlRequest::SetZoomAmount { amount } => unit(session.set_zoom_amount(amount)),
-        ControlRequest::SetAutoZoomOnClick { on } => unit(session.set_auto_zoom_on_click(on)),
-        ControlRequest::StartRecording => unit(session.start_recording()),
+        ControlRequest::SetZoomStyle {
+            hold,
+            pre_roll,
+            hl_zoom,
+            hl_pan,
+        } => unit(session.set_zoom_style(ZoomStyle {
+            hold,
+            pre_roll,
+            hl_zoom,
+            hl_pan,
+        })),
+        ControlRequest::StartRecording { auto_zoom_on_click } => {
+            // The agent drives via clicks, so click-zoom defaults ON for agent recordings.
+            if let Err(e) = session.set_auto_zoom_on_click(auto_zoom_on_click.unwrap_or(true)) {
+                return ControlResponse::error(e);
+            }
+            match session.start_recording() {
+                Ok(()) => ControlResponse::Ok,
+                Err(e) => {
+                    // A failed start must not leave the agent flag armed for a later
+                    // interactive recording.
+                    session.reset_agent_pending();
+                    ControlResponse::error(e)
+                }
+            }
+        }
         ControlRequest::StopRecording => match session.stop_recording() {
             Ok(s) => ControlResponse::Recording(RecordingSummary {
                 duration: s.duration,
@@ -168,8 +352,10 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             }),
             Err(e) => ControlResponse::error(e),
         },
+        ControlRequest::CancelRecording => unit(session.cancel_recording()),
         ControlRequest::SetPaused { paused } => unit(session.set_record_paused(paused)),
-        ControlRequest::Seek { t } => unit(session.seek(t)),
+        ControlRequest::Status => ControlResponse::Status(session.status()),
+        ControlRequest::Seek { t } => unit(session.seek_output(t)),
         ControlRequest::ClipState => match session.clip_info() {
             Ok(c) => ControlResponse::Clip(c),
             Err(e) => ControlResponse::error(e),
@@ -178,18 +364,58 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             Ok(frames) => ControlResponse::Frames { frames },
             Err(e) => ControlResponse::error(e),
         },
+        // Edit ops answer with the updated span lists (via clip_info, the single source of
+        // truth for the index ↔ span mapping the agent edits by).
+        ControlRequest::AddZoom { t } => zooms_after(session, session.add_zoom(t).map(|_| ())),
+        ControlRequest::UpdateZoom {
+            index,
+            start,
+            end,
+            amount,
+        } => zooms_after(
+            session,
+            session.update_zoom(index, start, end, amount).map(|_| ()),
+        ),
+        ControlRequest::SetZoomFocus { index, x, y } => {
+            let focus = match (x, y) {
+                (Some(x), Some(y)) => Some((x, y)),
+                _ => None,
+            };
+            zooms_after(session, session.set_zoom_focus(index, focus).map(|_| ()))
+        }
+        ControlRequest::RemoveZoom { index } => {
+            zooms_after(session, session.delete_zoom(index).map(|_| ()))
+        }
+        ControlRequest::AddCut { start, end } => {
+            cuts_after(session, session.add_cut(start, end).map(|_| ()))
+        }
+        ControlRequest::UpdateCut { index, start, end } => {
+            cuts_after(session, session.update_cut(index, start, end).map(|_| ()))
+        }
+        ControlRequest::RemoveCut { index } => {
+            cuts_after(session, session.delete_cut(index).map(|_| ()))
+        }
+        ControlRequest::AutoSpeed { factor } => match session.auto_speed(factor) {
+            Ok(_) => match session.clip_info() {
+                Ok(c) => ControlResponse::Speeds { speeds: c.speeds },
+                Err(e) => ControlResponse::error(e),
+            },
+            Err(e) => ControlResponse::error(e),
+        },
+        ControlRequest::ClearSpeed => unit(session.clear_speed()),
+        ControlRequest::SetTrim { start, end } => unit(session.set_trim(start, end)),
         ControlRequest::ExportGif {
             path,
             fps,
             width,
             quality,
-        } => unit(session.export_gif(path, fps, width, quality, &|_, _| {})),
+        } => start_export(app, ExportKind::Gif, path, fps, width, quality),
         ControlRequest::ExportMp4 {
             path,
             fps,
             width,
             quality,
-        } => unit(session.export_mp4(path, fps, width, quality, &|_, _| {})),
+        } => start_export(app, ExportKind::Mp4, path, fps, width, quality),
         ControlRequest::EstimateGif {
             fps,
             width,
@@ -198,7 +424,23 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             Ok(bytes) => ControlResponse::Size { bytes },
             Err(e) => ControlResponse::error(e),
         },
-        // Ping + injection + geometry already handled above.
+        // Ping + injection + geometry + export status already handled above.
         _ => ControlResponse::error("unhandled request"),
+    }
+}
+
+/// After a zoom edit, answer with the updated zoom spans (or the edit's error).
+fn zooms_after(session: &crate::session::Session, r: Result<(), String>) -> ControlResponse {
+    match r.and_then(|()| session.clip_info()) {
+        Ok(c) => ControlResponse::Zooms { zooms: c.zooms },
+        Err(e) => ControlResponse::error(e),
+    }
+}
+
+/// After a cut edit, answer with the updated cut spans (or the edit's error).
+fn cuts_after(session: &crate::session::Session, r: Result<(), String>) -> ControlResponse {
+    match r.and_then(|()| session.clip_info()) {
+        Ok(c) => ControlResponse::Cuts { cuts: c.cuts },
+        Err(e) => ControlResponse::error(e),
     }
 }

--- a/src-tauri/src/control_server.rs
+++ b/src-tauri/src/control_server.rs
@@ -134,6 +134,29 @@ fn unit(r: Result<(), String>) -> ControlResponse {
     }
 }
 
+/// Collapse the four optional `rect_*` components into a single rect, present only when all
+/// four are given (the protocol treats a partial rect as "no rect").
+fn rect_from(
+    x: Option<f64>,
+    y: Option<f64>,
+    w: Option<f64>,
+    h: Option<f64>,
+) -> Option<(f64, f64, f64, f64)> {
+    match (x, y, w, h) {
+        (Some(x), Some(y), Some(w), Some(h)) => Some((x, y, w, h)),
+        _ => None,
+    }
+}
+
+/// Record where the agent just pointed (physical px) into the running session, so injected
+/// typing can be given a caret focus at stop time. Silent no-op if the engine isn't booted
+/// or nothing is recording — this must never fail an injection.
+fn note_pointer(app: &AppHandle, x: i32, y: i32) {
+    if let Ok(session) = app.state::<Engine>().session() {
+        session.note_injected_pointer(x, y);
+    }
+}
+
 // ── Export jobs ─────────────────────────────────────────────────────────────────────
 //
 // Exports take minutes; running them inline would block the connection (and the agent's
@@ -238,7 +261,11 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             });
         }
         ControlRequest::MoveCursor { x, y, duration_ms } => {
-            return unit(vuoom_input::move_cursor_smooth(*x, *y, *duration_ms));
+            let r = vuoom_input::move_cursor_smooth(*x, *y, *duration_ms);
+            if r.is_ok() {
+                note_pointer(app, *x, *y);
+            }
+            return unit(r);
         }
         ControlRequest::Click {
             x,
@@ -247,13 +274,11 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             double,
             glide_ms,
         } => {
-            return unit(vuoom_input::click(
-                *x,
-                *y,
-                map_button(*button),
-                *double,
-                *glide_ms,
-            ));
+            let r = vuoom_input::click(*x, *y, map_button(*button), *double, *glide_ms);
+            if r.is_ok() {
+                note_pointer(app, *x, *y);
+            }
+            return unit(r);
         }
         ControlRequest::Drag {
             x1,
@@ -263,14 +288,12 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             button,
             duration_ms,
         } => {
-            return unit(vuoom_input::drag(
-                *x1,
-                *y1,
-                *x2,
-                *y2,
-                map_button(*button),
-                *duration_ms,
-            ));
+            let r = vuoom_input::drag(*x1, *y1, *x2, *y2, map_button(*button), *duration_ms);
+            // The caret ends at the drag's release point.
+            if r.is_ok() {
+                note_pointer(app, *x2, *y2);
+            }
+            return unit(r);
         }
         ControlRequest::TypeText { text, cps } => {
             return unit(vuoom_input::type_text(text, *cps));
@@ -323,11 +346,19 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
             pre_roll,
             hl_zoom,
             hl_pan,
+            merge_gap,
+            merge_radius,
+            min_rezoom_interval,
+            dead_zone,
         } => unit(session.set_zoom_style(ZoomStyle {
             hold,
             pre_roll,
             hl_zoom,
             hl_pan,
+            merge_gap,
+            merge_radius,
+            min_rezoom_interval,
+            dead_zone,
         })),
         ControlRequest::StartRecording { auto_zoom_on_click } => {
             // The agent drives via clicks, so click-zoom defaults ON for agent recordings.
@@ -366,22 +397,54 @@ fn dispatch(app: &AppHandle, req: ControlRequest) -> ControlResponse {
         },
         // Edit ops answer with the updated span lists (via clip_info, the single source of
         // truth for the index ↔ span mapping the agent edits by).
-        ControlRequest::AddZoom { t } => zooms_after(session, session.add_zoom(t).map(|_| ())),
+        ControlRequest::AddZoom {
+            t,
+            rect_x,
+            rect_y,
+            rect_w,
+            rect_h,
+            hl_zoom_in,
+            hl_zoom_out,
+        } => {
+            let rect = rect_from(rect_x, rect_y, rect_w, rect_h);
+            zooms_after(
+                session,
+                session
+                    .add_zoom(t, rect, hl_zoom_in, hl_zoom_out)
+                    .map(|_| ()),
+            )
+        }
         ControlRequest::UpdateZoom {
             index,
             start,
             end,
             amount,
+            hl_zoom_in,
+            hl_zoom_out,
         } => zooms_after(
             session,
-            session.update_zoom(index, start, end, amount).map(|_| ()),
+            session
+                .update_zoom(index, start, end, amount, hl_zoom_in, hl_zoom_out)
+                .map(|_| ()),
         ),
-        ControlRequest::SetZoomFocus { index, x, y } => {
+        ControlRequest::SetZoomFocus {
+            index,
+            x,
+            y,
+            rect_x,
+            rect_y,
+            rect_w,
+            rect_h,
+        } => {
             let focus = match (x, y) {
                 (Some(x), Some(y)) => Some((x, y)),
                 _ => None,
             };
-            zooms_after(session, session.set_zoom_focus(index, focus).map(|_| ()))
+            let rect = rect_from(rect_x, rect_y, rect_w, rect_h);
+            zooms_after(
+                session,
+                session.set_zoom_focus(index, focus, rect).map(|_| ()),
+            )
         }
         ControlRequest::RemoveZoom { index } => {
             zooms_after(session, session.delete_zoom(index).map(|_| ()))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,13 @@ pub fn run() {
             commands::check_recovery,
             commands::recover_session,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        .run(|_app, event| {
+            if let tauri::RunEvent::Exit = event {
+                // Drop the control-server discovery file so a stale endpoint never points
+                // a future MCP sidecar at a dead port.
+                control_server::cleanup();
+            }
+        });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 //! `docs/02-Architecture.md`.
 
 mod commands;
+mod control_server;
 mod frame_store;
 mod hotkey;
 mod live_preview;
@@ -88,6 +89,8 @@ pub fn run() {
                 let _ = main.maximize();
             }
             build_tray(app.handle())?;
+            // AI Demo Director control server (opt-in via VUOOM_ENABLE_CONTROL); no-op otherwise.
+            control_server::start(app.handle().clone());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1392,6 +1392,8 @@ impl Session {
             amount,
             mode: ZoomMode::Auto,
             edge_snap_ratio: project.zoom_config.edge_snap_ratio,
+            hl_zoom_in: None,
+            hl_zoom_out: None,
         };
         vuoom_zoom::insert_sorted(&mut project.zooms, kf);
         let zooms = project.zooms.clone();

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -22,7 +22,7 @@ use base64::Engine;
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use vuoom_capture::{spawn_region, CaptureHandle, CapturedFrame, CropRegion};
-use vuoom_control::{ClipInfo, FrameShot};
+use vuoom_control::{ClipInfo, CutSpan, FrameShot, RecordState, SpeedSpan, StatusInfo, ZoomSpan};
 use vuoom_encode::{
     downscale_rgba, encode_png_to_vec, estimate_delta_total_bytes, export_gif_native,
     export_gif_native_streaming, read_png, swizzle_rb, write_png, GifSettings, RgbaImage,
@@ -160,7 +160,25 @@ pub struct Session {
     pending_zoom: Mutex<f64>,
     /// Whether clicks auto-seed zooms for the next recording. Off for the interactive default
     /// (manual hotkey); the AI Demo Director turns it on since the agent drives via clicks.
+    /// Reset to the default at stop/cancel so agent recordings never contaminate a later
+    /// interactive one.
     pending_auto_click: Mutex<bool>,
+    /// Zoom-feel overrides for the next recording (AI Demo Director); reset at stop/cancel.
+    pending_style: Mutex<ZoomStyle>,
+}
+
+/// Optional zoom-feel overrides the AI Demo Director can set for its next recording.
+/// `None` fields keep [`ZoomConfig::default`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ZoomStyle {
+    /// Seconds of inactivity before the camera zooms back out.
+    pub hold: Option<f64>,
+    /// Seconds of anticipation before a click that the zoom-in begins.
+    pub pre_roll: Option<f64>,
+    /// Half-life (s) of the zoom spring.
+    pub hl_zoom: Option<f64>,
+    /// Half-life (s) of the pan spring.
+    pub hl_pan: Option<f64>,
 }
 
 impl Session {
@@ -181,6 +199,7 @@ impl Session {
             pending_monitor: Mutex::new(None),
             pending_zoom: Mutex::new(ZoomConfig::default().amount),
             pending_auto_click: Mutex::new(ZoomConfig::default().auto_zoom_on_click),
+            pending_style: Mutex::new(ZoomStyle::default()),
         })
     }
 
@@ -215,6 +234,30 @@ impl Session {
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = on;
         Ok(())
+    }
+
+    /// Set zoom-feel overrides for the next recording (AI Demo Director); clamped to the
+    /// ranges the editor allows. Reset to defaults when the recording stops.
+    pub fn set_zoom_style(&self, style: ZoomStyle) -> Result<(), String> {
+        let clamped = ZoomStyle {
+            hold: style.hold.map(|v| v.clamp(0.2, 10.0)),
+            pre_roll: style.pre_roll.map(|v| v.clamp(0.0, 2.0)),
+            hl_zoom: style.hl_zoom.map(|v| v.clamp(0.05, 1.5)),
+            hl_pan: style.hl_pan.map(|v| v.clamp(0.05, 1.5)),
+        };
+        *self.pending_style.lock().unwrap_or_else(|e| e.into_inner()) = clamped;
+        Ok(())
+    }
+
+    /// Reset the agent-scoped pending flags (click-zoom + zoom style) to their defaults.
+    /// Called at stop/cancel (and on a failed agent start) so an agent take never changes
+    /// how a later interactive recording behaves.
+    pub(crate) fn reset_agent_pending(&self) {
+        *self
+            .pending_auto_click
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = ZoomConfig::default().auto_zoom_on_click;
+        *self.pending_style.lock().unwrap_or_else(|e| e.into_inner()) = ZoomStyle::default();
     }
 
     /// Grab a single full-display frame and return it as a `data:image/png;base64,…` URL —
@@ -411,10 +454,16 @@ impl Session {
             .pending_auto_click
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let style = *self.pending_style.lock().unwrap_or_else(|e| e.into_inner());
+        let defaults = ZoomConfig::default();
         let cfg = ZoomConfig {
             amount,
             auto_zoom_on_click,
-            ..ZoomConfig::default()
+            hold: style.hold.unwrap_or(defaults.hold),
+            pre_roll: style.pre_roll.unwrap_or(defaults.pre_roll),
+            hl_zoom: style.hl_zoom.unwrap_or(defaults.hl_zoom),
+            hl_pan: style.hl_pan.unwrap_or(defaults.hl_pan),
+            ..defaults
         };
         let zooms = plan_zooms(&events, duration, &cfg);
         let fps = if duration > 0.0 {
@@ -478,11 +527,62 @@ impl Session {
             ..Edited::default()
         };
 
+        // Agent-scoped flags apply to exactly one recording.
+        self.reset_agent_pending();
+
         Ok(RecordingSummary {
             duration,
             frames: frame_count,
             zooms: zoom_count,
         })
+    }
+
+    /// Stop capturing and **discard** the take: no project is built, the previous clip (if
+    /// any) stays loaded. The cheap way for the AI Demo Director to abandon a botched take.
+    pub fn cancel_recording(&self) -> Result<(), String> {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(mut session) = active.take() else {
+            return Err("not recording".into());
+        };
+        session._preview.stop();
+        session.capture.stop();
+        session.recorder.stop();
+        session.drain_stop.store(true, Ordering::Relaxed);
+        if let Some(drain) = session.drain.take() {
+            // Join so the store files are closed before a new recording reuses the
+            // recovery directory; the frames themselves are thrown away.
+            let _ = drain.join();
+        }
+        let _ = session.zoom_poll.finish();
+        self.reset_agent_pending();
+        Ok(())
+    }
+
+    /// What the engine is doing right now (for the AI Demo Director's `status` tool).
+    #[must_use]
+    pub fn status(&self) -> StatusInfo {
+        let active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(s) = active.as_ref() {
+            let paused = s.pauses.last().is_some_and(|(_, e)| e.is_none());
+            return StatusInfo {
+                state: if paused {
+                    RecordState::Paused
+                } else {
+                    RecordState::Recording
+                },
+                elapsed: Some(self.clock.seconds_between(s.start_qpc, self.clock.now())),
+            };
+        }
+        drop(active);
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
+        StatusInfo {
+            state: if edited.project.is_some() {
+                RecordState::ClipReady
+            } else {
+                RecordState::Idle
+            },
+            elapsed: None,
+        }
     }
 
     /// Composite the frame at time `t` (seconds) and publish it to the preview.
@@ -911,22 +1011,56 @@ impl Session {
         })
     }
 
-    /// A compact, serializable view of the clip for the AI Demo Director's control API.
+    /// The full editable state of the clip for the AI Demo Director's control API: both
+    /// durations plus every zoom/cut/speed span, so the agent knows exactly *where* to
+    /// sample frames and which segment index to repair — instead of guessing from counts.
     pub fn clip_info(&self) -> Result<ClipInfo, String> {
         let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
+        let (_, span, regions, cuts) = out_mapping(project);
         Ok(ClipInfo {
             duration: project.source.duration,
-            zooms: project.zooms.len(),
-            cuts: project.cuts.len(),
-            speed_regions: project.speed_regions.len(),
+            output_duration: output_duration(span, &regions, &cuts),
+            zooms: project
+                .zooms
+                .iter()
+                .map(|k| ZoomSpan {
+                    start: k.start,
+                    end: k.end,
+                    amount: k.amount,
+                    focus: match k.mode {
+                        ZoomMode::Manual { pos } => Some((pos.x, pos.y)),
+                        ZoomMode::Auto => None,
+                    },
+                })
+                .collect(),
+            cuts: project
+                .cuts
+                .iter()
+                .map(|c| CutSpan {
+                    start: c.start,
+                    end: c.end,
+                })
+                .collect(),
+            speeds: project
+                .speed_regions
+                .iter()
+                .map(|r| SpeedSpan {
+                    start: r.start,
+                    end: r.end,
+                    factor: r.factor,
+                })
+                .collect(),
         })
     }
 
-    /// Composite the clip at each of `times` (seconds) and return the frames as base64 PNGs,
-    /// so the AI Demo Director can *see* its output and critique it. Annotations are baked in
-    /// (unlike the live preview), so the agent sees exactly what export will produce. Pass
-    /// `max_width` to downscale each frame and keep the vision payload small.
+    /// Composite the clip at each of `times` (**output-timeline** seconds) and return the
+    /// frames as base64 PNGs, so the AI Demo Director can *see* its output and critique it.
+    ///
+    /// Times map through trim + cuts + speed exactly like export does, so `t` here shows
+    /// what the exported GIF shows at `t` — sampling in source time would let the agent
+    /// critique frames inside cuts that never ship. Annotations are baked in (unlike the
+    /// live preview). Pass `max_width` to downscale and keep the vision payload small.
     pub fn sample_frames(
         &self,
         times: &[f64],
@@ -942,12 +1076,16 @@ impl Session {
         }
         let (out_w, out_h) = project.output_dims();
         let bg = background_color(&project.frame);
+        let (t0, span, regions, cuts) = out_mapping(project);
+        let d_out = output_duration(span, &regions, &cuts);
         let mut shots = Vec::with_capacity(times.len());
         for &t in times {
-            let idx =
-                nearest_idx(store.recs(), self.clock, edited.start_qpc, t).ok_or("no frames")?;
+            let t_out = t.clamp(0.0, d_out);
+            let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
+            let idx = nearest_idx(store.recs(), self.clock, edited.start_qpc, t_src)
+                .ok_or("no frames")?;
             let frame = store.frame(idx)?;
-            let scene = build_scene(project, track, out_w, out_h, t);
+            let scene = build_scene(project, track, out_w, out_h, t_src);
             let rgba = compositor.composite_scene(
                 &frame.bgra,
                 frame.width,
@@ -966,13 +1104,56 @@ impl Session {
             let png = encode_png_to_vec(&img).map_err(|e| e.to_string())?;
             let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
             shots.push(FrameShot {
-                t,
+                t: t_out,
                 width: img.width,
                 height: img.height,
                 png_base64: b64,
             });
         }
         Ok(shots)
+    }
+
+    /// [`Session::seek`], but `t` is on the **output timeline** (the control API's time
+    /// space) — mapped through trim + cuts + speed before compositing.
+    pub fn seek_output(&self, t: f64) -> Result<(), String> {
+        let t_src = {
+            let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
+            let project = edited.project.as_ref().ok_or("no recording")?;
+            let (t0, span, regions, cuts) = out_mapping(project);
+            let d_out = output_duration(span, &regions, &cuts);
+            t0 + output_to_source(t.clamp(0.0, d_out), span, &regions, &cuts)
+        };
+        self.seek(t_src)
+    }
+
+    /// Capture the recording monitor **right now** and return it as a downscalable PNG shot
+    /// — the AI Demo Director's eyes while driving (before/without any recording).
+    pub fn screenshot_shot(&self, max_width: Option<u32>) -> Result<FrameShot, String> {
+        let monitor = self
+            .pending_monitor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .map(|m| m.name.clone());
+        let (rx, handle) = spawn_region(None, monitor);
+        let frame = rx.recv_timeout(std::time::Duration::from_secs(3));
+        // Stop the capture thread on every path — including a timeout — so a slow or failed
+        // grab can't leak a live capture session and its GPU/duplication resources.
+        handle.stop();
+        let frame = frame.map_err(|e| format!("screenshot capture failed: {e}"))?;
+        let mut img = RgbaImage::new(frame.width, frame.height, swizzle_rb(&frame.bgra));
+        if let Some(mw) = max_width {
+            if mw > 0 && mw < img.width {
+                img = downscale_rgba(&img, mw);
+            }
+        }
+        let png = encode_png_to_vec(&img).map_err(|e| e.to_string())?;
+        Ok(FrameShot {
+            t: 0.0,
+            width: img.width,
+            height: img.height,
+            png_base64: base64::engine::general_purpose::STANDARD.encode(&png),
+        })
     }
 
     /// Toggle click ripples (drawn in both the preview and the exported GIF).

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -213,7 +213,7 @@ impl Session {
         *self
             .pending_auto_click
             .lock()
-            .map_err(|_| "lock poisoned")? = on;
+            .unwrap_or_else(|e| e.into_inner()) = on;
         Ok(())
     }
 
@@ -913,7 +913,7 @@ impl Session {
 
     /// A compact, serializable view of the clip for the AI Demo Director's control API.
     pub fn clip_info(&self) -> Result<ClipInfo, String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
         Ok(ClipInfo {
             duration: project.source.duration,
@@ -932,7 +932,7 @@ impl Session {
         times: &[f64],
         max_width: Option<u32>,
     ) -> Result<Vec<FrameShot>, String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
         let project = edited.project.as_ref().ok_or("no recording")?;
         let track = edited.track.as_ref().ok_or("no recording")?;
@@ -944,7 +944,8 @@ impl Session {
         let bg = background_color(&project.frame);
         let mut shots = Vec::with_capacity(times.len());
         for &t in times {
-            let idx = nearest_idx(store, self.clock, edited.start_qpc, t).ok_or("no frames")?;
+            let idx =
+                nearest_idx(store.recs(), self.clock, edited.start_qpc, t).ok_or("no frames")?;
             let frame = store.frame(idx)?;
             let scene = build_scene(project, track, out_w, out_h, t);
             let rgba = compositor.composite_scene(

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -33,6 +33,7 @@ use vuoom_project::{
     HighlightBox, HighlightShape, KeyTap, Project, Rect, Shadow, SourceInfo, SpeedRegion,
     TextAnnotation, TimeRange, Trim, ZoomConfig, ZoomKeyframe,
 };
+use vuoom_control::{ClipInfo, FrameShot};
 use vuoom_render::{build_scene, Compositor};
 use vuoom_zoom::{plan_zooms, simulate, CameraTrack, InputEvent, ZoomMode};
 
@@ -890,6 +891,69 @@ impl Session {
             }
             .into(),
         })
+    }
+
+    /// A compact, serializable view of the clip for the AI Demo Director's control API.
+    pub fn clip_info(&self) -> Result<ClipInfo, String> {
+        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let project = edited.project.as_ref().ok_or("no recording")?;
+        Ok(ClipInfo {
+            duration: project.source.duration,
+            zooms: project.zooms.len(),
+            cuts: project.cuts.len(),
+            speed_regions: project.speed_regions.len(),
+        })
+    }
+
+    /// Composite the clip at each of `times` (seconds) and return the frames as base64 PNGs,
+    /// so the AI Demo Director can *see* its output and critique it. Annotations are baked in
+    /// (unlike the live preview), so the agent sees exactly what export will produce. Pass
+    /// `max_width` to downscale each frame and keep the vision payload small.
+    pub fn sample_frames(
+        &self,
+        times: &[f64],
+        max_width: Option<u32>,
+    ) -> Result<Vec<FrameShot>, String> {
+        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
+        let project = edited.project.as_ref().ok_or("no recording")?;
+        let track = edited.track.as_ref().ok_or("no recording")?;
+        let store = edited.frames.as_ref().ok_or("no frames")?;
+        if store.is_empty() {
+            return Err("no frames".into());
+        }
+        let (out_w, out_h) = project.output_dims();
+        let bg = background_color(&project.frame);
+        let mut shots = Vec::with_capacity(times.len());
+        for &t in times {
+            let idx = nearest_idx(store, self.clock, edited.start_qpc, t).ok_or("no frames")?;
+            let frame = store.frame(idx)?;
+            let scene = build_scene(project, track, out_w, out_h, t);
+            let rgba = compositor.composite_scene(
+                &frame.bgra,
+                frame.width,
+                frame.height,
+                out_w,
+                out_h,
+                &scene,
+                bg,
+            );
+            let mut img = RgbaImage::new(out_w, out_h, rgba);
+            if let Some(mw) = max_width {
+                if mw > 0 && mw < out_w {
+                    img = downscale_rgba(&img, mw);
+                }
+            }
+            let png = encode_png_to_vec(&img).map_err(|e| e.to_string())?;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+            shots.push(FrameShot {
+                t,
+                width: img.width,
+                height: img.height,
+                png_base64: b64,
+            });
+        }
+        Ok(shots)
     }
 
     /// Toggle click ripples (drawn in both the preview and the exported GIF).

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -22,7 +22,9 @@ use base64::Engine;
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use vuoom_capture::{spawn_region, CaptureHandle, CapturedFrame, CropRegion};
-use vuoom_control::{ClipInfo, CutSpan, FrameShot, RecordState, SpeedSpan, StatusInfo, ZoomSpan};
+use vuoom_control::{
+    ClipInfo, CutSpan, FrameShot, PreviewInfo, RecordState, SpeedSpan, StatusInfo, ZoomSpan,
+};
 use vuoom_encode::{
     downscale_rgba, encode_png_to_vec, estimate_delta_total_bytes, export_gif_native,
     export_gif_native_streaming, read_png, swizzle_rb, write_png, GifSettings, RgbaImage,
@@ -1218,6 +1220,99 @@ impl Session {
         Ok(shots)
     }
 
+    /// Composite a cheap low-res animated GIF over `[start, end]` (output-timeline seconds)
+    /// so the agent can critique motion/pacing/easing *before* a full export. Reuses the
+    /// same compositing path as [`Session::sample_frames`], downscales to `width`, and
+    /// encodes in-process with the pure-Rust GIF encoder at a modest single-pass quality
+    /// (no lossy second pass — this is a throwaway proxy, not a deliverable).
+    ///
+    /// Bounded to `MAX_PREVIEW_FRAMES` low-res frames so it stays well inside the client's
+    /// read timeout — hence a plain synchronous request, not an async export job.
+    pub fn preview_clip(
+        &self,
+        start: Option<f64>,
+        end: Option<f64>,
+        fps: Option<f64>,
+        width: Option<u32>,
+    ) -> Result<PreviewInfo, String> {
+        /// Hard cap: an over-long preview would blow the sync request budget.
+        const MAX_PREVIEW_FRAMES: usize = 120;
+
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
+        let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
+        let project = edited.project.as_ref().ok_or("no recording")?;
+        let track = edited.track.as_ref().ok_or("no recording")?;
+        let store = edited.frames.as_ref().ok_or("no frames")?;
+        if store.is_empty() {
+            return Err("no frames".into());
+        }
+        let (out_w, out_h) = project.output_dims();
+        let bg = background_color(&project.frame);
+        let (t0, span, regions, cuts) = out_mapping(project);
+        let d_out = output_duration(span, &regions, &cuts);
+
+        // Fractional fps is rounded to a whole number so the GIF frame delay stays honest.
+        let fps = (fps.unwrap_or(5.0).round() as u32).clamp(1, 10);
+        let width = width.unwrap_or(480).clamp(160, 640);
+        let start = start.unwrap_or(0.0).clamp(0.0, d_out);
+        let end = end.unwrap_or(d_out).clamp(0.0, d_out);
+        if end - start < 1e-3 {
+            return Err("preview range is empty — end must be greater than start".into());
+        }
+        let duration = end - start;
+        let count = ((duration * f64::from(fps)).ceil() as usize).max(1);
+        if count > MAX_PREVIEW_FRAMES {
+            return Err(format!(
+                "preview would need {count} frames (max {MAX_PREVIEW_FRAMES}) — raise start, lower end, or lower fps"
+            ));
+        }
+
+        let mut frames = Vec::with_capacity(count);
+        for i in 0..count {
+            let t_out = (start + i as f64 / f64::from(fps)).min(end);
+            let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
+            let idx = nearest_idx(store.recs(), self.clock, edited.start_qpc, t_src)
+                .ok_or("no frames")?;
+            let frame = store.frame(idx)?;
+            let scene = build_scene(project, track, out_w, out_h, t_src);
+            let rgba = compositor.composite_scene(
+                &frame.bgra,
+                frame.width,
+                frame.height,
+                out_w,
+                out_h,
+                &scene,
+                bg,
+            );
+            let mut img = RgbaImage::new(out_w, out_h, rgba);
+            if width < out_w {
+                img = downscale_rgba(&img, width);
+            }
+            frames.push(img);
+        }
+        let (w, h) = (frames[0].width, frames[0].height);
+        // Cheapest GIF path: single global-palette pass at modest quality, frames already
+        // downscaled (so `width: None`), and no lossy gifsicle second pass.
+        let settings = GifSettings {
+            fps,
+            width: None,
+            quality: 60,
+            lossy: None,
+        };
+        let tmp = std::env::temp_dir().join(format!("vuoom-preview-{}.gif", std::process::id()));
+        export_gif_native(&frames, &settings, &tmp).map_err(|e| e.to_string())?;
+        let bytes = std::fs::read(&tmp).map_err(|e| e.to_string())?;
+        let _ = std::fs::remove_file(&tmp);
+        let gif_base64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        Ok(PreviewInfo {
+            gif_base64,
+            frame_count: count,
+            width: w,
+            height: h,
+            duration,
+        })
+    }
+
     /// [`Session::seek`], but `t` is on the **output timeline** (the control API's time
     /// space) — mapped through trim + cuts + speed before compositing.
     pub fn seek_output(&self, t: f64) -> Result<(), String> {
@@ -1325,14 +1420,23 @@ impl Session {
         })
     }
 
-    /// Detect idle stretches (no clicks/keys/scrolls for `MIN_GAP` seconds) and mark them
+    /// Detect idle stretches (no clicks/keys/scrolls for `min_gap` seconds) and mark them
     /// to play at `factor`×. Replaces any existing speed regions; returns the new list.
-    pub fn auto_speed(&self, factor: f64) -> Result<Vec<SpeedRegion>, String> {
-        /// An idle gap must be at least this long (s) to be worth skimming.
-        const MIN_GAP: f64 = 2.5;
-        /// Keep normal speed for a beat after the last action / before the next one.
-        const LEAD: f64 = 0.6;
-        const TAIL: f64 = 0.4;
+    ///
+    /// `min_gap` (default 2.5, clamp 0.5–30.0): idle gaps shorter than this stay at 1×.
+    /// `lead`/`tail` (defaults 0.6 / 0.4, clamp 0.0–5.0): seconds kept at normal speed
+    /// after the last action and before the next one. Omitting all three reproduces the
+    /// original hardcoded behaviour exactly.
+    pub fn auto_speed(
+        &self,
+        factor: f64,
+        min_gap: Option<f64>,
+        lead: Option<f64>,
+        tail: Option<f64>,
+    ) -> Result<Vec<SpeedRegion>, String> {
+        let min_gap = min_gap.unwrap_or(2.5).clamp(0.5, 30.0);
+        let lead = lead.unwrap_or(0.6).clamp(0.0, 5.0);
+        let tail = tail.unwrap_or(0.4).clamp(0.0, 5.0);
 
         let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
@@ -1351,9 +1455,9 @@ impl Session {
         let mut regions = Vec::new();
         let mut prev = 0.0_f64;
         for m in marks.into_iter().chain(std::iter::once(d)) {
-            if m - prev >= MIN_GAP {
-                let start = (prev + LEAD).max(0.0);
-                let end = (m - TAIL).min(d);
+            if m - prev >= min_gap {
+                let start = (prev + lead).max(0.0);
+                let end = (m - tail).min(d);
                 if end - start > 0.5 {
                     regions.push(SpeedRegion { start, end, factor });
                 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -35,7 +35,7 @@ use vuoom_project::{
     TextAnnotation, TimeRange, Trim, ZoomConfig, ZoomKeyframe,
 };
 use vuoom_render::{build_scene, Compositor};
-use vuoom_zoom::{plan_zooms, simulate, CameraTrack, InputEvent, ZoomMode};
+use vuoom_zoom::{plan_zooms, simulate, CameraTrack, InputEvent, NormRect, ZoomMode};
 
 /// Summary returned to the UI when recording stops.
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -95,6 +95,12 @@ struct Active {
     /// Pause spans `(start_qpc, end_qpc)` — an open span means "currently paused".
     /// Converted to cuts at stop time, so pauses stay editable in the timeline.
     pauses: Vec<(i64, Option<i64>)>,
+    /// Pointer positions `(qpc, x, y)` in physical virtual-desktop px that the AI Demo
+    /// Director injected (click / move / drag). At stop time these give injected typing a
+    /// caret focus (the agent types where it last clicked) so the planner can steer an
+    /// `Auto` span toward the text. Empty for interactive recordings, so human typing keeps
+    /// no caret (the raw hook can't tell the caret from the mouse — see `normalize()`).
+    caret_trail: Vec<(i64, i32, i32)>,
     /// Decoupled live "director's monitor" — dropped (and stopped) when recording ends.
     _preview: LivePreview,
 }
@@ -179,6 +185,14 @@ pub struct ZoomStyle {
     pub hl_zoom: Option<f64>,
     /// Half-life (s) of the pan spring.
     pub hl_pan: Option<f64>,
+    /// Clicks within this gap (s) may merge into one zoom.
+    pub merge_gap: Option<f64>,
+    /// Clicks within this normalized distance of a cluster merge into it.
+    pub merge_radius: Option<f64>,
+    /// Minimum seconds between the end of one zoom and the start of the next.
+    pub min_rezoom_interval: Option<f64>,
+    /// Normalized half-extent the focus must leave before the pan retargets.
+    pub dead_zone: Option<f64>,
 }
 
 impl Session {
@@ -244,6 +258,10 @@ impl Session {
             pre_roll: style.pre_roll.map(|v| v.clamp(0.0, 2.0)),
             hl_zoom: style.hl_zoom.map(|v| v.clamp(0.05, 1.5)),
             hl_pan: style.hl_pan.map(|v| v.clamp(0.05, 1.5)),
+            merge_gap: style.merge_gap.map(|v| v.clamp(0.1, 5.0)),
+            merge_radius: style.merge_radius.map(|v| v.clamp(0.02, 1.0)),
+            min_rezoom_interval: style.min_rezoom_interval.map(|v| v.clamp(0.0, 10.0)),
+            dead_zone: style.dead_zone.map(|v| v.clamp(0.0, 0.5)),
         };
         *self.pending_style.lock().unwrap_or_else(|e| e.into_inner()) = clamped;
         Ok(())
@@ -346,9 +364,19 @@ impl Session {
             start_qpc: self.clock.now(),
             zoom_poll: ZoomChordPoller::start(),
             pauses: Vec::new(),
+            caret_trail: Vec::new(),
             _preview: preview,
         });
         Ok(())
+    }
+
+    /// Record a pointer position the AI Demo Director just injected (physical px), so
+    /// injected typing can be given a caret focus at stop time. No-op when not recording.
+    pub fn note_injected_pointer(&self, x: i32, y: i32) {
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(s) = active.as_mut() {
+            s.caret_trail.push((self.clock.now(), x, y));
+        }
     }
 
     /// Pause / resume the running recording. Capture keeps running; the paused span is
@@ -449,6 +477,39 @@ impl Session {
         }
         events.sort_by(|a, b| a.t().total_cmp(&b.t()));
 
+        // Give injected typing a caret focus. The AI Demo Director types where it last
+        // clicked, so back-fill each caret-less `KeyType` with the injected pointer position
+        // active at that instant. The planner uses this to steer an `Auto` span toward the
+        // text (never to seed a new zoom). The trail is empty for interactive recordings, so
+        // human typing is untouched (the raw hook deliberately leaves those `pos: None`).
+        if !session.caret_trail.is_empty() {
+            let mut trail: Vec<(f64, DVec2)> = session
+                .caret_trail
+                .iter()
+                .map(|&(qpc, x, y)| {
+                    let t = self.clock.seconds_between(session.start_qpc, qpc);
+                    let pos = DVec2::new(
+                        (f64::from(x - region.x) / f64::from(region.w.max(1))).clamp(0.0, 1.0),
+                        (f64::from(y - region.y) / f64::from(region.h.max(1))).clamp(0.0, 1.0),
+                    );
+                    (t, pos)
+                })
+                .collect();
+            trail.sort_by(|a, b| a.0.total_cmp(&b.0));
+            for e in &mut events {
+                if let InputEvent::KeyType { t, pos } = e {
+                    if pos.is_none() {
+                        // The latest injected pointer at or before this keystroke.
+                        if let Some(&(_, p)) =
+                            trail.iter().take_while(|(tt, _)| *tt <= *t + 1e-6).last()
+                        {
+                            *pos = Some(p);
+                        }
+                    }
+                }
+            }
+        }
+
         let amount = *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner());
         let auto_zoom_on_click = *self
             .pending_auto_click
@@ -463,6 +524,12 @@ impl Session {
             pre_roll: style.pre_roll.unwrap_or(defaults.pre_roll),
             hl_zoom: style.hl_zoom.unwrap_or(defaults.hl_zoom),
             hl_pan: style.hl_pan.unwrap_or(defaults.hl_pan),
+            merge_gap: style.merge_gap.unwrap_or(defaults.merge_gap),
+            merge_radius: style.merge_radius.unwrap_or(defaults.merge_radius),
+            min_rezoom_interval: style
+                .min_rezoom_interval
+                .unwrap_or(defaults.min_rezoom_interval),
+            dead_zone: style.dead_zone.unwrap_or(defaults.dead_zone),
             ..defaults
         };
         let zooms = plan_zooms(&events, duration, &cfg);
@@ -1015,23 +1082,60 @@ impl Session {
     /// durations plus every zoom/cut/speed span, so the agent knows exactly *where* to
     /// sample frames and which segment index to repair — instead of guessing from counts.
     pub fn clip_info(&self) -> Result<ClipInfo, String> {
+        /// Camera-path sample rate on the output timeline.
+        const CAMERA_HZ: f64 = 4.0;
+        /// Hard cap on camera samples, so a long clip stays cheap (rate drops instead).
+        const CAMERA_CAP: usize = 200;
+
         let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
-        let (_, span, regions, cuts) = out_mapping(project);
+        let (t0, span, regions, cuts) = out_mapping(project);
+        let d_out = output_duration(span, &regions, &cuts);
+
+        // Sample the stored camera track at a coarse fixed rate. The track lives on the
+        // SOURCE timeline, so map each output time through trim + cuts + speed exactly like
+        // `sample_frames`/`get_frames` do — the agent then reads camera and frames in the
+        // same time space.
+        let camera = edited.track.as_ref().map_or_else(Vec::new, |track| {
+            let n = (((d_out * CAMERA_HZ).ceil() as usize) + 1).clamp(1, CAMERA_CAP);
+            let step = if n > 1 { d_out / (n - 1) as f64 } else { 0.0 };
+            (0..n)
+                .map(|i| {
+                    let t_out = (i as f64 * step).min(d_out);
+                    let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
+                    let cs = track.at(t_src);
+                    (t_out, cs.center.x, cs.center.y, cs.zoom)
+                })
+                .collect()
+        });
+
         Ok(ClipInfo {
             duration: project.source.duration,
-            output_duration: output_duration(span, &regions, &cuts),
+            output_duration: d_out,
             zooms: project
                 .zooms
                 .iter()
-                .map(|k| ZoomSpan {
-                    start: k.start,
-                    end: k.end,
-                    amount: k.amount,
-                    focus: match k.mode {
-                        ZoomMode::Manual { pos } => Some((pos.x, pos.y)),
-                        ZoomMode::Auto => None,
-                    },
+                .map(|k| {
+                    let (focus, mode, rect) = match k.mode {
+                        ZoomMode::Auto => (None, "auto", None),
+                        ZoomMode::Manual { pos } => (Some((pos.x, pos.y)), "manual", None),
+                        ZoomMode::Rect { rect } => {
+                            let c = rect.center();
+                            (
+                                Some((c.x, c.y)),
+                                "rect",
+                                Some((rect.x, rect.y, rect.w, rect.h)),
+                            )
+                        }
+                    };
+                    ZoomSpan {
+                        start: k.start,
+                        end: k.end,
+                        amount: k.amount,
+                        focus,
+                        mode: mode.to_string(),
+                        rect,
+                    }
                 })
                 .collect(),
             cuts: project
@@ -1051,6 +1155,7 @@ impl Session {
                     factor: r.factor,
                 })
                 .collect(),
+            camera,
         })
     }
 
@@ -1367,10 +1472,22 @@ impl Session {
         Ok(project.cuts.clone())
     }
 
-    /// Insert a manual zoom segment at time `t` and re-simulate the camera.
-    /// Returns the updated segment list.
-    pub fn add_zoom(&self, t: f64) -> Result<Vec<ZoomKeyframe>, String> {
+    /// Insert a manual zoom segment at time `t` and re-simulate the camera. Provide `rect`
+    /// (all four normalized components) to frame a region (fit-and-centre); otherwise the
+    /// segment follows the cursor. `hl_in`/`hl_out` optionally override the per-span zoom
+    /// spring half-lives. Returns the updated segment list.
+    pub fn add_zoom(
+        &self,
+        t: f64,
+        rect: Option<(f64, f64, f64, f64)>,
+        hl_in: Option<f64>,
+        hl_out: Option<f64>,
+    ) -> Result<Vec<ZoomKeyframe>, String> {
         const DEFAULT_LEN: f64 = 2.0;
+        let mode = match rect {
+            Some(r) => rect_to_mode(r)?,
+            None => ZoomMode::Auto,
+        };
         let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
@@ -1390,10 +1507,11 @@ impl Session {
             start,
             end,
             amount,
-            mode: ZoomMode::Auto,
+            mode,
             edge_snap_ratio: project.zoom_config.edge_snap_ratio,
-            hl_zoom_in: None,
-            hl_zoom_out: None,
+            // A value <= 0 means "no override"; the camera would clamp it anyway.
+            hl_zoom_in: hl_in.filter(|v| *v > 0.0),
+            hl_zoom_out: hl_out.filter(|v| *v > 0.0),
         };
         vuoom_zoom::insert_sorted(&mut project.zooms, kf);
         let zooms = project.zooms.clone();
@@ -1401,14 +1519,18 @@ impl Session {
         Ok(zooms)
     }
 
-    /// Retime / re-level the zoom segment at `index` and re-simulate the camera.
-    /// Returns the updated segment list.
+    /// Retime / re-level the zoom segment at `index` and re-simulate the camera. For the
+    /// per-span spring half-lives, `None` leaves the current value unchanged, a value `> 0`
+    /// sets it, and a value `<= 0` clears it back to the config default. Returns the updated
+    /// segment list.
     pub fn update_zoom(
         &self,
         index: usize,
         start: f64,
         end: f64,
         amount: f64,
+        hl_in: Option<f64>,
+        hl_out: Option<f64>,
     ) -> Result<Vec<ZoomKeyframe>, String> {
         let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
@@ -1419,6 +1541,12 @@ impl Session {
         }
         if let Some(kf) = project.zooms.get_mut(index) {
             kf.amount = amount.clamp(1.1, 4.0);
+            if let Some(v) = hl_in {
+                kf.hl_zoom_in = (v > 0.0).then_some(v);
+            }
+            if let Some(v) = hl_out {
+                kf.hl_zoom_out = (v > 0.0).then_some(v);
+            }
         }
         vuoom_zoom::sort_by_start(&mut project.zooms);
         let zooms = project.zooms.clone();
@@ -1426,23 +1554,27 @@ impl Session {
         Ok(zooms)
     }
 
-    /// Set how the zoom segment at `index` picks its focus: `Some((x, y))` holds a fixed
-    /// normalized point, `None` follows the cursor. Returns the updated segment list.
+    /// Set how the zoom segment at `index` picks its focus. Precedence: `rect` (all four
+    /// normalized components) frames a region (fit-and-centre); else `focus` holds a fixed
+    /// point; else the camera follows the cursor. Returns the updated segment list.
     pub fn set_zoom_focus(
         &self,
         index: usize,
         focus: Option<(f64, f64)>,
+        rect: Option<(f64, f64, f64, f64)>,
     ) -> Result<Vec<ZoomKeyframe>, String> {
+        let mode = match (rect, focus) {
+            (Some(r), _) => rect_to_mode(r)?,
+            (None, Some((x, y))) => ZoomMode::Manual {
+                pos: DVec2::new(x.clamp(0.0, 1.0), y.clamp(0.0, 1.0)),
+            },
+            (None, None) => ZoomMode::Auto,
+        };
         let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let kf = project.zooms.get_mut(index).ok_or("no such zoom segment")?;
-        kf.mode = match focus {
-            Some((x, y)) => ZoomMode::Manual {
-                pos: DVec2::new(x.clamp(0.0, 1.0), y.clamp(0.0, 1.0)),
-            },
-            None => ZoomMode::Auto,
-        };
+        kf.mode = mode;
         let zooms = project.zooms.clone();
         resimulate(&mut edited);
         Ok(zooms)
@@ -2026,6 +2158,25 @@ fn extract_key_taps(raw: &[RawEvent], clock: Clock, start_qpc: i64, duration: f6
     taps
 }
 
+/// Validate a normalized `(x, y, w, h)` rect into a [`ZoomMode::Rect`]: clamp the corner
+/// into `[0, 1]`, shrink the size so it stays inside the frame, and reject a degenerate
+/// (zero/negative area) rect with a clear error.
+fn rect_to_mode(rect: (f64, f64, f64, f64)) -> Result<ZoomMode, String> {
+    let (rx, ry, rw, rh) = rect;
+    if rw <= 0.0 || rh <= 0.0 {
+        return Err("zoom rect must have positive width and height".into());
+    }
+    let x = rx.clamp(0.0, 1.0);
+    let y = ry.clamp(0.0, 1.0);
+    let w = rw.min(1.0 - x).max(0.0);
+    let h = rh.min(1.0 - y).max(0.0);
+    let nrect = NormRect { x, y, w, h };
+    if nrect.is_degenerate() {
+        return Err("zoom rect is outside the frame (nothing left to frame)".into());
+    }
+    Ok(ZoomMode::Rect { rect: nrect })
+}
+
 /// Keep speed regions in timeline order (the editor identifies them by sorted index).
 fn sort_speed(regions: &mut [SpeedRegion]) {
     regions.sort_by(|a, b| a.start.total_cmp(&b.start));
@@ -2143,5 +2294,44 @@ mod tests {
         // Rounds to the nearer neighbour.
         assert_eq!(nearest_idx(&recs, clock, start, 1.4), Some(1));
         assert_eq!(nearest_idx(&recs, clock, start, 1.6), Some(2));
+    }
+
+    #[test]
+    fn rect_to_mode_accepts_a_valid_rect() {
+        let mode = rect_to_mode((0.2, 0.3, 0.4, 0.25)).expect("valid rect");
+        match mode {
+            ZoomMode::Rect { rect } => {
+                assert!((rect.x - 0.2).abs() < 1e-9);
+                assert!((rect.w - 0.4).abs() < 1e-9);
+            }
+            other => panic!("expected Rect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rect_to_mode_clamps_the_corner_and_shrinks_to_fit() {
+        // A corner past 1.0 clamps in, and an oversized width shrinks to stay inside [0,1].
+        let mode = rect_to_mode((0.8, 0.9, 0.5, 0.2)).expect("clamped rect");
+        match mode {
+            ZoomMode::Rect { rect } => {
+                assert!(
+                    rect.x + rect.w <= 1.0 + 1e-9,
+                    "rect escaped the frame: {rect:?}"
+                );
+                assert!(
+                    rect.y + rect.h <= 1.0 + 1e-9,
+                    "rect escaped the frame: {rect:?}"
+                );
+            }
+            other => panic!("expected Rect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rect_to_mode_rejects_degenerate_rects() {
+        assert!(rect_to_mode((0.2, 0.2, 0.0, 0.3)).is_err());
+        assert!(rect_to_mode((0.2, 0.2, 0.3, -0.1)).is_err());
+        // A corner clamped to the far edge leaves no room, so the rect is rejected.
+        assert!(rect_to_mode((1.0, 0.5, 0.3, 0.3)).is_err());
     }
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -22,6 +22,7 @@ use base64::Engine;
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use vuoom_capture::{spawn_region, CaptureHandle, CapturedFrame, CropRegion};
+use vuoom_control::{ClipInfo, FrameShot};
 use vuoom_encode::{
     downscale_rgba, encode_png_to_vec, estimate_delta_total_bytes, export_gif_native,
     export_gif_native_streaming, read_png, swizzle_rb, write_png, GifSettings, RgbaImage,
@@ -33,7 +34,6 @@ use vuoom_project::{
     HighlightBox, HighlightShape, KeyTap, Project, Rect, Shadow, SourceInfo, SpeedRegion,
     TextAnnotation, TimeRange, Trim, ZoomConfig, ZoomKeyframe,
 };
-use vuoom_control::{ClipInfo, FrameShot};
 use vuoom_render::{build_scene, Compositor};
 use vuoom_zoom::{plan_zooms, simulate, CameraTrack, InputEvent, ZoomMode};
 

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -158,6 +158,9 @@ pub struct Session {
     pending_monitor: Mutex<Option<MonitorInfo>>,
     /// The zoom multiplier chosen for the next recording (1.0 = no zoom).
     pending_zoom: Mutex<f64>,
+    /// Whether clicks auto-seed zooms for the next recording. Off for the interactive default
+    /// (manual hotkey); the AI Demo Director turns it on since the agent drives via clicks.
+    pending_auto_click: Mutex<bool>,
 }
 
 impl Session {
@@ -177,6 +180,7 @@ impl Session {
             pending_region: Mutex::new(None),
             pending_monitor: Mutex::new(None),
             pending_zoom: Mutex::new(ZoomConfig::default().amount),
+            pending_auto_click: Mutex::new(ZoomConfig::default().auto_zoom_on_click),
         })
     }
 
@@ -201,6 +205,15 @@ impl Session {
     /// Set the zoom multiplier for the next recording (clamped to a sane range).
     pub fn set_zoom_amount(&self, amount: f64) -> Result<(), String> {
         *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner()) = amount.clamp(1.0, 4.0);
+        Ok(())
+    }
+
+    /// Enable/disable click-driven auto-zoom for the next recording (see [`Session`]).
+    pub fn set_auto_zoom_on_click(&self, on: bool) -> Result<(), String> {
+        *self
+            .pending_auto_click
+            .lock()
+            .map_err(|_| "lock poisoned")? = on;
         Ok(())
     }
 
@@ -394,8 +407,13 @@ impl Session {
         events.sort_by(|a, b| a.t().total_cmp(&b.t()));
 
         let amount = *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner());
+        let auto_zoom_on_click = *self
+            .pending_auto_click
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let cfg = ZoomConfig {
             amount,
+            auto_zoom_on_click,
             ..ZoomConfig::default()
         };
         let zooms = plan_zooms(&events, duration, &cfg);


### PR DESCRIPTION
Implements the full improvement plan from mcp_improve.md (review of the original MCP branch), rebased on main.

## Smoothness (the recordings looked robotic)
- Minimum-jerk cursor glides (distance-scaled), settle-then-click, paced typing (~15 cps, jittered), stepped scrolling, drag support
- The glide streams real move events through the input hook, so the auto-zoom camera pans smoothly too

## The critique loop (was half-blind)
- `screenshot` — live perception while driving
- `clip_state` returns zoom/cut/speed spans + output_duration (not counts)
- `get_frames`/`seek` sample the OUTPUT timeline — exactly what exports
- Edit ops over the protocol: repair zooms/cuts/speed/trim without re-recording
- `status` + `cancel_recording` for recovery

## Correctness & hardening
- SendInput short-count → error (UIPI/elevated targets no longer fail silently)
- KEYEVENTF_EXTENDEDKEY for the nav cluster; OEM punctuation chords (ctrl+=)
- Auth token in the discovery file; connect/read timeouts; VUOOM_ENABLE_CONTROL=0 disables; discovery file removed on exit
- Exports are polled jobs — a minutes-long encode can no longer wedge a tool call
- Agent-scoped zoom flags reset at stop/cancel (never leak into interactive use)

## Tests
- Protocol round-trips incl. optional-field defaults; auth handshake integration test; humanizer math unit tests; MCP router smoke test (all 35 tools)

Runtime pass on a real machine still needed (see docs/IMPLEMENTATION-STATUS.md v2 table).