### PR TITLE
fix: full-audit batch — Win11 backdrop, engine guards, robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "base64 0.22.1",
  "glam",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-capture"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-encode"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "color_quant",
  "gif",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-input"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "glam",
  "thiserror 2.0.18",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-preview"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "futures-util",
  "thiserror 2.0.18",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-project"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "glam",
  "serde",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-render"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "bytemuck",
  "glam",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "vuoom-zoom"
-version = "0.1.26"
+version = "0.1.28"
 dependencies = [
  "glam",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.1.28"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["The Vuoom Authors"]
-repository = "https://github.com/vuoom/vuoom"
+repository = "https://github.com/Razee4315/Vuoom"
 rust-version = "1.80"
 
 # Shared dependency versions — pin once, reference with `dep.workspace = true`.

--- a/crates/vuoom-encode/src/gifski.rs
+++ b/crates/vuoom-encode/src/gifski.rs
@@ -14,13 +14,15 @@ use std::process::Command;
 /// Build the gifski CLI arguments for the given settings, PNG frame paths, and output.
 #[must_use]
 pub fn build_gifski_args(settings: &GifSettings, frames: &[String], out: &str) -> Vec<String> {
+    // gifski rejects quality outside 1..=100 with an opaque error; clamp defensively.
+    let quality = settings.quality.clamp(1, 100);
     let mut args = vec![
         "-o".to_string(),
         out.to_string(),
         "--fps".to_string(),
         settings.fps.to_string(),
         "--quality".to_string(),
-        settings.quality.to_string(),
+        quality.to_string(),
         "--quiet".to_string(),
     ];
     if let Some(w) = settings.width {
@@ -34,6 +36,8 @@ pub fn build_gifski_args(settings: &GifSettings, frames: &[String], out: &str) -
 /// Build a gifsicle "shrink more" second-pass command (lossy + dedup), editing in place.
 #[must_use]
 pub fn build_gifsicle_args(lossy: u8, gif_path: &str) -> Vec<String> {
+    // gifsicle's `--lossy` tops out around 200; clamp so a stray value can't fail the pass.
+    let lossy = lossy.min(200);
     vec![
         "-O3".to_string(),
         format!("--lossy={lossy}"),
@@ -120,6 +124,24 @@ mod tests {
         assert!(args.contains(&"--lossy=80".to_string()));
         assert!(args.contains(&"-b".to_string()));
         assert_eq!(args.last().unwrap(), "out.gif");
+    }
+
+    #[test]
+    fn quality_is_clamped_to_gifski_range() {
+        let s = GifSettings {
+            quality: 250,
+            ..GifSettings::readme()
+        };
+        let args = build_gifski_args(&s, &["f.png".to_string()], "o.gif");
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--quality" && w[1] == "100"));
+    }
+
+    #[test]
+    fn lossy_is_clamped_to_gifsicle_range() {
+        let args = build_gifsicle_args(255, "o.gif");
+        assert!(args.contains(&"--lossy=200".to_string()));
     }
 
     #[test]

--- a/crates/vuoom-encode/src/lib.rs
+++ b/crates/vuoom-encode/src/lib.rs
@@ -18,6 +18,9 @@ pub use error::EncodeError;
 pub use export::export_gif;
 pub use gifski::{build_gifsicle_args, build_gifski_args, run_gifsicle, run_gifski};
 pub use image::{encode_png_to_vec, read_png, swizzle_rb, write_png, RgbaImage};
-pub use native::{downscale_rgba, export_gif_native, frame_delay_cs, quality_to_speed};
+pub use native::{
+    downscale_rgba, export_gif_native, export_gif_native_streaming, frame_delay_cs,
+    quality_to_speed,
+};
 pub use plan::{estimate_delta_total_bytes, estimate_total_bytes, plan_frames, EmittedFrame};
 pub use settings::GifSettings;

--- a/crates/vuoom-encode/src/native.rs
+++ b/crates/vuoom-encode/src/native.rs
@@ -26,6 +26,9 @@ const PALETTE_COLORS: usize = 255;
 /// Pixel budget for training the global palette (~1 MB of RGBA samples, spread evenly
 /// across the whole clip so late scenes get palette slots too).
 const PALETTE_SAMPLE_PIXELS: usize = 1 << 18;
+/// Frames the streaming encoder composites to train the global palette — enough spread for
+/// a representative palette without holding the whole clip in RAM.
+const PALETTE_SAMPLE_FRAMES: usize = 48;
 
 /// Box-filter downscale to `target_w`, preserving aspect ratio. Never upscales: returns a
 /// clone when `target_w` is zero or already ≥ the source width.
@@ -291,6 +294,137 @@ pub fn export_gif_native(
     Ok(())
 }
 
+/// Streaming variant of [`export_gif_native`] for long clips. Instead of taking every
+/// composited frame up front (each is `out_w*out_h*4` bytes — gigabytes for a long 1080p
+/// export, which OOMs), it pulls frames one at a time from `frame(i)` and keeps only the
+/// current and previous indexed frames resident.
+///
+/// `frame(i)` composites and returns output frame `i` at full output resolution (this
+/// function applies the `settings.width` downscale and must be able to be called repeatedly
+/// with the same index). `progress(done, total)` ticks while the palette is sampled and
+/// while frames are encoded.
+///
+/// # Errors
+/// Returns [`EncodeError`] for zero frames, a `frame(i)` failure, mismatched/zero-size
+/// frame dimensions, or a write/encode failure.
+pub fn export_gif_native_streaming<F>(
+    count: usize,
+    mut frame: F,
+    settings: &GifSettings,
+    out: &Path,
+    progress: &dyn Fn(usize, usize),
+) -> Result<(), EncodeError>
+where
+    F: FnMut(usize) -> Result<RgbaImage, String>,
+{
+    if count == 0 {
+        return Err(EncodeError::NoFrames);
+    }
+    let scale = |img: RgbaImage| match settings.width {
+        Some(cap) => downscale_rgba(&img, cap),
+        None => img,
+    };
+
+    let sample_count = count.min(PALETTE_SAMPLE_FRAMES);
+    let total_work = sample_count + count;
+    let mut work = 0usize;
+
+    // ---- Pass 1: train the global palette on a spread of sample frames ----
+    let mut samples: Vec<RgbaImage> = Vec::with_capacity(sample_count);
+    let (mut w, mut h) = (0u32, 0u32);
+    for s in 0..sample_count {
+        let i = if sample_count <= 1 {
+            0
+        } else {
+            s * (count - 1) / (sample_count - 1)
+        };
+        let img = scale(frame(i).map_err(EncodeError::Gif)?);
+        if s == 0 {
+            w = img.width;
+            h = img.height;
+        } else if img.width != w || img.height != h {
+            return Err(EncodeError::Gif("frame dimensions differ".into()));
+        }
+        samples.push(img);
+        work += 1;
+        progress(work, total_work);
+    }
+    if w == 0 || h == 0 {
+        return Err(EncodeError::Gif("zero-size frame".into()));
+    }
+    let mut quant = GlobalQuantizer::train(&samples, quality_to_speed(settings.quality));
+    drop(samples); // free the sample frames before the encode pass
+    let palette = quant.palette();
+    let (wu, hu) = (w as usize, h as usize);
+
+    // ---- Pass 2: encode, holding only the current + previous indexed frame ----
+    let file = File::create(out)?;
+    let mut encoder = gif::Encoder::new(BufWriter::new(file), w as u16, h as u16, &palette)
+        .map_err(|e| EncodeError::Gif(e.to_string()))?;
+    encoder
+        .set_repeat(gif::Repeat::Infinite)
+        .map_err(|e| EncodeError::Gif(e.to_string()))?;
+
+    let delay = u32::from(frame_delay_cs(settings.fps));
+    let first = scale(frame(0).map_err(EncodeError::Gif)?);
+    if first.width != w || first.height != h {
+        return Err(EncodeError::Gif("frame dimensions differ".into()));
+    }
+    let mut prev = quant.index_frame(&first);
+    drop(first);
+    let mut pending = PendingFrame {
+        left: 0,
+        top: 0,
+        width: w as u16,
+        height: h as u16,
+        buffer: prev.clone(),
+        delay_cs: delay,
+    };
+    work += 1;
+    progress(work, total_work);
+
+    for i in 1..count {
+        let img = scale(frame(i).map_err(EncodeError::Gif)?);
+        if img.width != w || img.height != h {
+            return Err(EncodeError::Gif("frame dimensions differ".into()));
+        }
+        let cur = quant.index_frame(&img);
+        match diff_bbox(&prev, &cur, wu, hu) {
+            // Identical frame: hold the pending frame on screen longer instead.
+            None => pending.delay_cs += delay,
+            Some((x0, y0, x1, y1)) => {
+                write_pending(&mut encoder, &pending)?;
+                let (bw, bh) = (x1 - x0, y1 - y0);
+                let mut buf = Vec::with_capacity(bw * bh);
+                for y in y0..y1 {
+                    let row = y * wu;
+                    for x in x0..x1 {
+                        let p = row + x;
+                        buf.push(if cur[p] == prev[p] {
+                            TRANSPARENT_INDEX
+                        } else {
+                            cur[p]
+                        });
+                    }
+                }
+                pending = PendingFrame {
+                    left: x0 as u16,
+                    top: y0 as u16,
+                    width: bw as u16,
+                    height: bh as u16,
+                    buffer: buf,
+                    delay_cs: delay,
+                };
+                prev = cur;
+            }
+        }
+        work += 1;
+        progress(work, total_work);
+    }
+    write_pending(&mut encoder, &pending)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +464,55 @@ mod tests {
         let src = solid(2, 2, [0, 0, 0, 255]);
         let out = downscale_rgba(&src, 8);
         assert_eq!((out.width, out.height), (2, 2));
+    }
+
+    #[test]
+    fn streaming_encoder_matches_frame_geometry() {
+        // The streaming encoder must produce the same frame layout as the in-memory one:
+        // a full keyframe then a delta rectangle over the changed pixels.
+        let base = solid(8, 8, [200, 30, 30, 255]);
+        let mut changed = base.clone();
+        // Flip a 2x2 block at (4,4) to a colour that's present in frame 0's palette set.
+        for y in 4..6 {
+            for x in 4..6 {
+                let o = ((y * 8 + x) * 4) as usize;
+                changed.pixels[o..o + 4].copy_from_slice(&[30, 30, 200, 255]);
+            }
+        }
+        let frames = [base, changed];
+        let out = std::env::temp_dir().join("vuoom-stream-test.gif");
+        let ticks = std::cell::Cell::new(0u32);
+        export_gif_native_streaming(
+            frames.len(),
+            |i| Ok(frames[i].clone()),
+            &GifSettings {
+                width: None,
+                ..GifSettings::readme()
+            },
+            &out,
+            &|_done, _total| ticks.set(ticks.get() + 1),
+        )
+        .unwrap();
+        assert!(ticks.get() > 0, "progress callback never fired");
+        let (has_global, decoded) = decode(&out);
+        assert!(has_global);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!((decoded[0].width, decoded[0].height), (8, 8)); // keyframe
+                                                                   // Second frame is a delta rectangle, smaller than the full frame.
+        assert!(decoded[1].width <= 8 && decoded[1].height <= 8);
+    }
+
+    #[test]
+    fn streaming_zero_count_is_an_error() {
+        let out = std::env::temp_dir().join("vuoom-stream-empty.gif");
+        let r = export_gif_native_streaming(
+            0,
+            |_i| Ok(solid(2, 2, [0, 0, 0, 255])),
+            &GifSettings::readme(),
+            &out,
+            &|_, _| {},
+        );
+        assert!(matches!(r, Err(EncodeError::NoFrames)));
     }
 
     #[test]

--- a/crates/vuoom-encode/src/native.rs
+++ b/crates/vuoom-encode/src/native.rs
@@ -225,6 +225,11 @@ pub fn export_gif_native(
     if scaled.iter().any(|f| f.width != w || f.height != h) {
         return Err(EncodeError::Gif("frame dimensions differ".into()));
     }
+    if w == 0 || h == 0 {
+        // A zero-pixel frame yields an empty palette sample set, which would panic the
+        // quantizer (`NeuQuant::new` on an empty slice divides by zero).
+        return Err(EncodeError::Gif("zero-size frame".into()));
+    }
     let (wu, hu) = (w as usize, h as usize);
 
     let mut quant = GlobalQuantizer::train(&scaled, quality_to_speed(settings.quality));
@@ -325,6 +330,15 @@ mod tests {
         let src = solid(2, 2, [0, 0, 0, 255]);
         let out = downscale_rgba(&src, 8);
         assert_eq!((out.width, out.height), (2, 2));
+    }
+
+    #[test]
+    fn zero_size_frame_is_an_error_not_a_panic() {
+        // A 0x0 frame used to reach the quantizer with an empty sample set and panic.
+        let frames = vec![solid(0, 0, [0, 0, 0, 255])];
+        let out = std::env::temp_dir().join("vuoom-zero-frame-test.gif");
+        let r = export_gif_native(&frames, &GifSettings::readme(), &out);
+        assert!(matches!(r, Err(EncodeError::Gif(_))));
     }
 
     #[test]

--- a/crates/vuoom-zoom/src/camera.rs
+++ b/crates/vuoom-zoom/src/camera.rs
@@ -30,6 +30,9 @@ impl Default for CameraState {
 ///
 /// `hl` is the half-life in seconds (time to close half the remaining distance).
 pub fn spring_update(x: &mut f64, v: &mut f64, goal: f64, hl: f64, dt: f64) {
+    // Guard against a zero/negative half-life: it would make `y` infinite and poison the
+    // whole track with NaN (every `hl_*` is user-editable in the inspector).
+    let hl = hl.max(1e-4);
     // Critical damping derived from the half-life: y = 2*ln2 / hl.
     let y = 2.0 * LN_2 / hl;
     let j0 = *x - goal;
@@ -128,6 +131,8 @@ pub fn simulate(
     fps: f64,
     cfg: &ZoomConfig,
 ) -> CameraTrack {
+    // A zero/negative fps would make `dt` infinite and NaN-poison the whole track.
+    let fps = fps.max(1.0);
     let frame_count = (duration * fps).ceil().max(1.0) as usize + 1;
     let dt = 1.0 / fps;
 
@@ -233,5 +238,24 @@ mod tests {
         assert_eq!(c, DVec2::new(0.25, 0.75));
         // At zoom 1.0 the only valid center is the middle.
         assert_eq!(clamp_camera(DVec2::new(0.0, 0.0), 1.0), DVec2::splat(0.5));
+    }
+
+    #[test]
+    fn spring_zero_half_life_does_not_nan() {
+        // hl=0 used to make `y` infinite -> NaN; the guard must keep it finite.
+        let (mut x, mut v) = (0.0, 0.0);
+        spring_update(&mut x, &mut v, 1.0, 0.0, 1.0 / 60.0);
+        assert!(x.is_finite() && v.is_finite(), "x={x} v={v}");
+    }
+
+    #[test]
+    fn simulate_zero_fps_produces_finite_track() {
+        // fps=0 used to make `dt` infinite -> a NaN-poisoned track.
+        let track = simulate(&[], &[], 1.0, 0.0, &ZoomConfig::default());
+        assert!(!track.frames().is_empty());
+        assert!(track
+            .frames()
+            .iter()
+            .all(|f| f.zoom.is_finite() && f.center.x.is_finite() && f.center.y.is_finite()));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -51,17 +51,26 @@ fn restore_editor(app: &AppHandle) {
     }
 }
 
-/// Step 1 — the user clicked Record: hide the editor from the capture and blow it up to
-/// fullscreen so the in-window region selector covers the display.
+/// Step 1 — the user clicked Record: capture the desktop for the selector backdrop, then
+/// blow the editor up to fullscreen (excluded from capture) so the in-window region
+/// selector covers the display. Returns the backdrop as a `data:image/png;base64,…` URL
+/// (empty string if the grab failed — the selector then just shows a dark canvas).
 ///
 /// The recording targets the monitor the editor is on right now — fullscreen lands there,
 /// so drag Vuoom to another monitor to record that one.
+///
+/// Why the screenshot is taken while the window is **hidden** rather than relying on
+/// `WDA_EXCLUDEFROMCAPTURE`: on Windows 11 a *fullscreen* excluded window is composited
+/// through the direct-flip path and Windows Graphics Capture records its area as solid
+/// black (the desktop behind it is never sampled) — that produced the blank selector
+/// backdrop. Windows 10 happens to composite the desktop behind the excluded window, so it
+/// worked there. Hiding the window for the single grab is correct on both.
 #[tauri::command]
 pub fn enter_overlay(
     app: AppHandle,
     engine: tauri::State<'_, Engine>,
     border: tauri::State<'_, BorderState>,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let main = app.get_webview_window("main").ok_or("no main window")?;
     let monitor = main.current_monitor().ok().flatten();
     if let Ok(mut slot) = border.origin.lock() {
@@ -79,11 +88,24 @@ pub fn enter_overlay(
         });
         let _ = session.set_monitor(info);
     }
+
+    // Hide the window and let DWM recompose without it before grabbing the clean desktop.
+    let _ = main.hide();
+    std::thread::sleep(std::time::Duration::from_millis(120));
+    let backdrop = engine
+        .session()
+        .ok()
+        .and_then(|s| s.screenshot().ok())
+        .unwrap_or_default();
+
+    // Best-effort from here on: the window is currently hidden, so `show()` MUST run on
+    // every path — bailing early with `?` would strand an invisible window.
     let _ = exclude_from_capture(&main);
-    main.set_always_on_top(true).map_err(|e| e.to_string())?;
-    main.set_fullscreen(true).map_err(|e| e.to_string())?;
+    let _ = main.set_always_on_top(true);
+    let _ = main.set_fullscreen(true);
+    let _ = main.show();
     let _ = main.set_focus();
-    Ok(())
+    Ok(backdrop)
 }
 
 /// Width/height (logical px) of the recording panel — a live zoom preview + Stop controls.

--- a/src-tauri/src/frame_store.rs
+++ b/src-tauri/src/frame_store.rs
@@ -132,7 +132,7 @@ impl FrameStore {
     /// Load frame `i` (cached for repeat hits).
     pub fn frame(&self, i: usize) -> Result<Arc<CapturedFrame>, String> {
         let rec = *self.index.get(i).ok_or("no such frame")?;
-        let mut rs = self.read.lock().map_err(|_| "lock poisoned")?;
+        let mut rs = self.read.lock().unwrap_or_else(|e| e.into_inner());
         if let Some((ci, f)) = &rs.cache {
             if *ci == i {
                 return Ok(Arc::clone(f));

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -23,8 +23,8 @@ use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use vuoom_capture::{spawn_region, CaptureHandle, CapturedFrame, CropRegion};
 use vuoom_encode::{
-    downscale_rgba, encode_png_to_vec, estimate_delta_total_bytes, export_gif_native, read_png,
-    swizzle_rb, write_png, GifSettings, RgbaImage,
+    downscale_rgba, encode_png_to_vec, estimate_delta_total_bytes, export_gif_native,
+    export_gif_native_streaming, read_png, swizzle_rb, write_png, GifSettings, RgbaImage,
 };
 use vuoom_input::{normalize, zoom_marks, CaptureRegion, Clock, InputRecorder, RawEvent};
 use vuoom_preview::{pack_frame, FrameMeta, PreviewServer};
@@ -100,7 +100,10 @@ struct Active {
 
 #[derive(Default)]
 struct Edited {
-    frames: Option<FrameStore>,
+    /// `Arc` so an export can clone a handle under a short lock and then composite/encode
+    /// (minutes of work) without holding the `edited` mutex — keeping scrub/edit/record
+    /// responsive during export. The store reads frames from disk on demand.
+    frames: Option<Arc<FrameStore>>,
     project: Option<Project>,
     track: Option<CameraTrack>,
     start_qpc: i64,
@@ -440,7 +443,7 @@ impl Session {
         let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
         // Fresh clip → fresh (empty) undo history.
         *edited = Edited {
-            frames: Some(store),
+            frames: Some(Arc::new(store)),
             project: Some(project),
             track: Some(track),
             start_qpc: session.start_qpc,
@@ -505,12 +508,29 @@ impl Session {
         quality: u8,
         progress: &dyn Fn(u32, u32),
     ) -> Result<(), String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
-        let images = self.composite_output_frames(&edited, fps, 1, &|done, total| {
-            // Reserve the last tick for the encode step.
-            progress(done, total + 1);
-        })?;
-        let total = images.len() as u32 + 1;
+        // Snapshot the minimal state under a short lock, then release it so the (minutes-long)
+        // encode never blocks scrubbing/editing/starting a new recording. The frame store is
+        // shared via `Arc` and reads from disk on demand — frames are never all resident, so
+        // even an hour-long 1080p export stays within a bounded memory budget.
+        let (project, track, store, start_qpc) = {
+            let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+            (
+                edited.project.as_ref().ok_or("no recording")?.clone(),
+                edited.track.as_ref().ok_or("no recording")?.clone(),
+                Arc::clone(edited.frames.as_ref().ok_or("no frames")?),
+                edited.start_qpc,
+            )
+        };
+        if store.is_empty() {
+            return Err("no frames".into());
+        }
+        let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
+
+        let (out_w, out_h) = project.output_dims();
+        let bg = background_color(&project.frame);
+        let (t0, span, regions, cuts) = out_mapping(&project);
+        let d_out = output_duration(span, &regions, &cuts);
+        let count = ((d_out * f64::from(fps)).ceil() as usize).max(1);
 
         let settings = GifSettings {
             fps,
@@ -518,9 +538,36 @@ impl Session {
             quality,
             ..GifSettings::readme()
         };
-        export_gif_native(&images, &settings, Path::new(&out_path)).map_err(|e| e.to_string())?;
-        progress(total, total);
-        Ok(())
+
+        // Composite one output frame on demand — the streaming encoder pulls these and keeps
+        // only the current + previous frame resident.
+        let compose = |i: usize| -> Result<RgbaImage, String> {
+            let t_out = (i as f64 / f64::from(fps)).min(d_out);
+            let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
+            let idx = nearest_idx(&store, self.clock, start_qpc, t_src).ok_or("no frames")?;
+            let frame = store.frame(idx)?;
+            let scene = build_scene(&project, &track, out_w, out_h, t_src);
+            let rgba = compositor.composite_scene(
+                &frame.bgra,
+                frame.width,
+                frame.height,
+                out_w,
+                out_h,
+                &scene,
+                bg,
+            );
+            Ok(RgbaImage::new(out_w, out_h, rgba))
+        };
+        export_gif_native_streaming(
+            count,
+            compose,
+            &settings,
+            Path::new(&out_path),
+            &|done, total| {
+                progress(done as u32, total as u32);
+            },
+        )
+        .map_err(|e| e.to_string())
     }
 
     /// Composite the output timeline and encode an H.264 MP4 to `out_path`, streaming one
@@ -533,18 +580,25 @@ impl Session {
         quality: u8,
         progress: &dyn Fn(u32, u32),
     ) -> Result<(), String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
-        let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
-        let project = edited.project.as_ref().ok_or("no recording")?;
-        let track = edited.track.as_ref().ok_or("no recording")?;
-        let store = edited.frames.as_ref().ok_or("no frames")?;
+        // Snapshot under a short lock, then release it so the long encode doesn't freeze
+        // scrub/edit/record (see `export_gif`). MP4 already streams frame-by-frame.
+        let (project, track, store, start_qpc) = {
+            let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+            (
+                edited.project.as_ref().ok_or("no recording")?.clone(),
+                edited.track.as_ref().ok_or("no recording")?.clone(),
+                Arc::clone(edited.frames.as_ref().ok_or("no frames")?),
+                edited.start_qpc,
+            )
+        };
         if store.is_empty() {
             return Err("no frames".into());
         }
+        let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
 
         let (out_w, out_h) = project.output_dims();
         let bg = background_color(&project.frame);
-        let (t0, span, regions, cuts) = out_mapping(project);
+        let (t0, span, regions, cuts) = out_mapping(&project);
         let d_out = output_duration(span, &regions, &cuts);
         let total = ((d_out * f64::from(fps)).ceil() as usize).max(1);
 
@@ -568,7 +622,7 @@ impl Session {
         for i in 0..total {
             let t_out = (i as f64 / f64::from(fps)).min(d_out);
             let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
-            let idx = match nearest_idx(store, self.clock, edited.start_qpc, t_src) {
+            let idx = match nearest_idx(&store, self.clock, start_qpc, t_src) {
                 Some(idx) => idx,
                 None => {
                     frame_err = Some("no frames".into());
@@ -582,7 +636,7 @@ impl Session {
                     break;
                 }
             };
-            let scene = build_scene(project, track, out_w, out_h, t_src);
+            let scene = build_scene(&project, &track, out_w, out_h, t_src);
             let rgba = compositor.composite_scene(
                 &frame.bgra,
                 frame.width,
@@ -665,19 +719,6 @@ impl Session {
         let (_, span, regions, cuts) = out_mapping(project);
         let d_out = output_duration(span, &regions, &cuts);
         Ok(((d_out * f64::from(fps)).ceil() as usize).max(1))
-    }
-
-    /// Composite every `stride`-th output-timeline frame (honoring trim + speed regions).
-    fn composite_output_frames(
-        &self,
-        edited: &Edited,
-        fps: u32,
-        stride: usize,
-        progress: &dyn Fn(u32, u32),
-    ) -> Result<Vec<RgbaImage>, String> {
-        let total = self.output_frame_count(edited, fps)?;
-        let indices: Vec<usize> = (0..total).step_by(stride.max(1)).collect();
-        self.composite_indices(edited, fps, &indices, progress)
     }
 
     /// Composite specific output-timeline frame indices (honoring trim + speed regions).
@@ -1506,7 +1547,7 @@ impl Session {
         let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
         // Fresh clip → fresh (empty) undo history.
         *edited = Edited {
-            frames: Some(store),
+            frames: Some(Arc::new(store)),
             project: Some(project),
             track: Some(track),
             start_qpc: base,
@@ -1558,7 +1599,7 @@ impl Session {
         };
         let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
         *edited = Edited {
-            frames: Some(store),
+            frames: Some(Arc::new(store)),
             project: Some(project),
             track: Some(track),
             start_qpc,

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use crate::frame_store::{self, FrameStore, FrameWriter};
+use crate::frame_store::{self, FrameRec, FrameStore, FrameWriter};
 use crate::live_preview::LivePreview;
 use crate::zoom_chord::ZoomChordPoller;
 use base64::Engine;
@@ -181,19 +181,25 @@ impl Session {
 
     /// Set the capture region (physical px) for the next recording; `None` = full display.
     pub fn set_region(&self, region: Option<CropRegion>) -> Result<(), String> {
-        *self.pending_region.lock().map_err(|_| "lock poisoned")? = region;
+        *self
+            .pending_region
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = region;
         Ok(())
     }
 
     /// Set the monitor the next recording (and its selector screenshot) captures.
     pub fn set_monitor(&self, monitor: Option<MonitorInfo>) -> Result<(), String> {
-        *self.pending_monitor.lock().map_err(|_| "lock poisoned")? = monitor;
+        *self
+            .pending_monitor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = monitor;
         Ok(())
     }
 
     /// Set the zoom multiplier for the next recording (clamped to a sane range).
     pub fn set_zoom_amount(&self, amount: f64) -> Result<(), String> {
-        *self.pending_zoom.lock().map_err(|_| "lock poisoned")? = amount.clamp(1.0, 4.0);
+        *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner()) = amount.clamp(1.0, 4.0);
         Ok(())
     }
 
@@ -203,7 +209,7 @@ impl Session {
         let monitor = self
             .pending_monitor
             .lock()
-            .map_err(|_| "lock poisoned")?
+            .unwrap_or_else(|e| e.into_inner())
             .as_ref()
             .map(|m| m.name.clone());
         let (rx, handle) = spawn_region(None, monitor);
@@ -226,23 +232,26 @@ impl Session {
 
     /// Begin capturing the primary display + global input.
     pub fn start_recording(&self) -> Result<(), String> {
-        let mut active = self.active.lock().map_err(|_| "lock poisoned")?;
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
         if active.is_some() {
             return Err("already recording".into());
         }
-        let region = *self.pending_region.lock().map_err(|_| "lock poisoned")?;
+        let region = *self
+            .pending_region
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let monitor = self
             .pending_monitor
             .lock()
-            .map_err(|_| "lock poisoned")?
+            .unwrap_or_else(|e| e.into_inner())
             .clone();
         let mon_name = monitor.as_ref().map(|m| m.name.clone());
         let mon_origin = monitor.as_ref().map_or((0, 0), |m| (m.x, m.y));
-        let amount = *self.pending_zoom.lock().map_err(|_| "lock poisoned")?;
+        let amount = *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner());
 
         // Drop the previous clip BEFORE recreating the store files: its open handles point
         // at the same recovery directory this recording is about to replace.
-        *self.edited.lock().map_err(|_| "lock poisoned")? = Edited::default();
+        *self.edited.lock().unwrap_or_else(|e| e.into_inner()) = Edited::default();
         let writer = FrameWriter::create(frame_store::recovery_dir())?;
 
         let (frames_rx, capture) = spawn_region(region, mon_name.clone());
@@ -289,7 +298,7 @@ impl Session {
     /// turned into a cut at stop time, so it never appears in the output (and can be
     /// restored in the editor if the pause was a mistake).
     pub fn set_record_paused(&self, paused: bool) -> Result<(), String> {
-        let mut active = self.active.lock().map_err(|_| "lock poisoned")?;
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
         let session = active.as_mut().ok_or("not recording")?;
         let now = self.clock.now();
         let open = session.pauses.last().is_some_and(|(_, e)| e.is_none());
@@ -305,7 +314,7 @@ impl Session {
 
     /// Stop capturing and build the editable project (plan zooms, simulate the camera).
     pub fn stop_recording(&self) -> Result<RecordingSummary, String> {
-        let mut active = self.active.lock().map_err(|_| "lock poisoned")?;
+        let mut active = self.active.lock().unwrap_or_else(|e| e.into_inner());
         let Some(mut session) = active.take() else {
             return Err("not recording".into());
         };
@@ -383,7 +392,7 @@ impl Session {
         }
         events.sort_by(|a, b| a.t().total_cmp(&b.t()));
 
-        let amount = *self.pending_zoom.lock().map_err(|_| "lock poisoned")?;
+        let amount = *self.pending_zoom.lock().unwrap_or_else(|e| e.into_inner());
         let cfg = ZoomConfig {
             amount,
             ..ZoomConfig::default()
@@ -440,7 +449,7 @@ impl Session {
             );
         }
 
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         // Fresh clip → fresh (empty) undo history.
         *edited = Edited {
             frames: Some(Arc::new(store)),
@@ -459,12 +468,12 @@ impl Session {
 
     /// Composite the frame at time `t` (seconds) and publish it to the preview.
     pub fn seek(&self, t: f64) -> Result<(), String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let compositor = self.compositor.as_ref().ok_or("no GPU compositor")?;
         let project = edited.project.as_ref().ok_or("no recording")?;
         let track = edited.track.as_ref().ok_or("no recording")?;
         let store = edited.frames.as_ref().ok_or("no frames")?;
-        let idx = nearest_idx(store, self.clock, edited.start_qpc, t).ok_or("no frames")?;
+        let idx = nearest_idx(store.recs(), self.clock, edited.start_qpc, t).ok_or("no frames")?;
         let frame = store.frame(idx)?;
 
         let (out_w, out_h) = project.output_dims();
@@ -513,7 +522,7 @@ impl Session {
         // shared via `Arc` and reads from disk on demand — frames are never all resident, so
         // even an hour-long 1080p export stays within a bounded memory budget.
         let (project, track, store, start_qpc) = {
-            let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+            let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
             (
                 edited.project.as_ref().ok_or("no recording")?.clone(),
                 edited.track.as_ref().ok_or("no recording")?.clone(),
@@ -544,7 +553,7 @@ impl Session {
         let compose = |i: usize| -> Result<RgbaImage, String> {
             let t_out = (i as f64 / f64::from(fps)).min(d_out);
             let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
-            let idx = nearest_idx(&store, self.clock, start_qpc, t_src).ok_or("no frames")?;
+            let idx = nearest_idx(store.recs(), self.clock, start_qpc, t_src).ok_or("no frames")?;
             let frame = store.frame(idx)?;
             let scene = build_scene(&project, &track, out_w, out_h, t_src);
             let rgba = compositor.composite_scene(
@@ -583,7 +592,7 @@ impl Session {
         // Snapshot under a short lock, then release it so the long encode doesn't freeze
         // scrub/edit/record (see `export_gif`). MP4 already streams frame-by-frame.
         let (project, track, store, start_qpc) = {
-            let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+            let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
             (
                 edited.project.as_ref().ok_or("no recording")?.clone(),
                 edited.track.as_ref().ok_or("no recording")?.clone(),
@@ -622,7 +631,7 @@ impl Session {
         for i in 0..total {
             let t_out = (i as f64 / f64::from(fps)).min(d_out);
             let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
-            let idx = match nearest_idx(&store, self.clock, start_qpc, t_src) {
+            let idx = match nearest_idx(store.recs(), self.clock, start_qpc, t_src) {
                 Some(idx) => idx,
                 None => {
                     frame_err = Some("no frames".into());
@@ -682,7 +691,7 @@ impl Session {
         const MOTION_FUDGE: f64 = 1.15;
         const WINDOW: usize = 12;
 
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let total = self.output_frame_count(&edited, fps)?;
         let win = WINDOW.min(total);
         // One mid-clip window for short clips, two spread out for longer ones.
@@ -746,7 +755,8 @@ impl Session {
         for (done, &i) in indices.iter().enumerate() {
             let t_out = (i as f64 / f64::from(fps)).min(d_out);
             let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
-            let idx = nearest_idx(store, self.clock, edited.start_qpc, t_src).ok_or("no frames")?;
+            let idx = nearest_idx(store.recs(), self.clock, edited.start_qpc, t_src)
+                .ok_or("no frames")?;
             let frame = store.frame(idx)?;
             let scene = build_scene(project, track, out_w, out_h, t_src);
             let rgba = compositor.composite_scene(
@@ -766,7 +776,7 @@ impl Session {
 
     /// Add a text label at normalized `(x, y)`, visible for ~3s from time `t`. Returns its id.
     pub fn add_text(&self, text: String, x: f64, y: f64, t: f64) -> Result<u32, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let id = next_id(project);
@@ -788,7 +798,7 @@ impl Session {
 
     /// Add an arrow between normalized points, visible for ~3s from time `t`. Returns its id.
     pub fn add_arrow(&self, fx: f64, fy: f64, tx: f64, ty: f64, t: f64) -> Result<u32, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let id = next_id(project);
@@ -824,7 +834,7 @@ impl Session {
         t: f64,
         shape: HighlightShape,
     ) -> Result<u32, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let id = next_id(project);
@@ -843,7 +853,7 @@ impl Session {
 
     /// Add a translucent filled highlighter (marker-style) rectangle. Returns its id.
     pub fn add_highlighter(&self, x: f64, y: f64, w: f64, h: f64, t: f64) -> Result<u32, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let id = next_id(project);
@@ -863,7 +873,7 @@ impl Session {
 
     /// Snapshot everything the editor timeline binds to.
     pub fn clip_state(&self) -> Result<ClipState, String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
         Ok(ClipState {
             duration: project.source.duration,
@@ -955,7 +965,7 @@ impl Session {
         const LEAD: f64 = 0.6;
         const TAIL: f64 = 0.4;
 
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1000,7 +1010,7 @@ impl Session {
         end: f64,
         factor: f64,
     ) -> Result<Vec<SpeedRegion>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1023,7 +1033,7 @@ impl Session {
         end: f64,
         factor: f64,
     ) -> Result<Vec<SpeedRegion>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1044,7 +1054,7 @@ impl Session {
 
     /// Delete the speed region at `index`. Returns the updated list.
     pub fn delete_speed_region(&self, index: usize) -> Result<Vec<SpeedRegion>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         if index >= project.speed_regions.len() {
@@ -1056,7 +1066,7 @@ impl Session {
 
     /// Remove `[start, end]` from the output entirely. Returns the updated, sorted list.
     pub fn add_cut(&self, start: f64, end: f64) -> Result<Vec<Trim>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1069,7 +1079,7 @@ impl Session {
 
     /// Retime the cut at `index`. Returns the updated, sorted list.
     pub fn update_cut(&self, index: usize, start: f64, end: f64) -> Result<Vec<Trim>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1083,7 +1093,7 @@ impl Session {
 
     /// Restore the cut at `index` (the section plays again). Returns the updated list.
     pub fn delete_cut(&self, index: usize) -> Result<Vec<Trim>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         if index >= project.cuts.len() {
@@ -1097,7 +1107,7 @@ impl Session {
     /// Returns the updated segment list.
     pub fn add_zoom(&self, t: f64) -> Result<Vec<ZoomKeyframe>, String> {
         const DEFAULT_LEN: f64 = 2.0;
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1134,7 +1144,7 @@ impl Session {
         end: f64,
         amount: f64,
     ) -> Result<Vec<ZoomKeyframe>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let d = project.source.duration;
@@ -1157,7 +1167,7 @@ impl Session {
         index: usize,
         focus: Option<(f64, f64)>,
     ) -> Result<Vec<ZoomKeyframe>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let kf = project.zooms.get_mut(index).ok_or("no such zoom segment")?;
@@ -1175,7 +1185,7 @@ impl Session {
     /// Delete the zoom segment at `index` and re-simulate the camera.
     /// Returns the updated segment list.
     pub fn delete_zoom(&self, index: usize) -> Result<Vec<ZoomKeyframe>, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         vuoom_zoom::remove(&mut project.zooms, index).ok_or("no such zoom segment")?;
@@ -1186,7 +1196,7 @@ impl Session {
 
     /// Snapshot every annotation for the editor overlay.
     pub fn annotations(&self) -> Result<AnnotationSet, String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
         Ok(AnnotationSet {
             texts: project.texts.clone(),
@@ -1418,7 +1428,7 @@ impl Session {
     /// visible next to the original. Returns the new id.
     pub fn duplicate_annotation(&self, id: u32) -> Result<u32, String> {
         const NUDGE: f64 = 0.03;
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, "");
         let project = edited.project.as_mut().ok_or("no recording")?;
         let new_id = next_id(project);
@@ -1461,7 +1471,7 @@ impl Session {
     /// Save the recording as a `dir.vuoom` bundle: the project manifest plus every frame
     /// as a lossless PNG and a time index. Reopenable with [`Self::open_bundle`].
     pub fn save_bundle(&self, dir: &Path) -> Result<(), String> {
-        let edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let project = edited.project.as_ref().ok_or("no recording")?;
         let store = edited.frames.as_ref().ok_or("no recording")?;
         let frames_dir = dir.join("frames");
@@ -1512,7 +1522,7 @@ impl Session {
         // Decode into the recovery-dir frame store: one frame in memory at a time, and the
         // opened project becomes the recoverable session like a fresh recording would.
         // Drop the current clip first — its store handles point at the same files.
-        *self.edited.lock().map_err(|_| "lock poisoned")? = Edited::default();
+        *self.edited.lock().unwrap_or_else(|e| e.into_inner()) = Edited::default();
         let mut writer = FrameWriter::create(frame_store::recovery_dir())?;
         for fi in &index {
             let img = read_png(&frames_dir.join(format!("{:05}.png", fi.n)))
@@ -1544,7 +1554,7 @@ impl Session {
             frames: store.len(),
             zooms: project.zooms.len(),
         };
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         // Fresh clip → fresh (empty) undo history.
         *edited = Edited {
             frames: Some(Arc::new(store)),
@@ -1597,7 +1607,7 @@ impl Session {
             frames: store.len(),
             zooms: project.zooms.len(),
         };
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         *edited = Edited {
             frames: Some(Arc::new(store)),
             project: Some(project),
@@ -1614,7 +1624,7 @@ impl Session {
     where
         F: FnOnce(&mut Project) -> Result<(), String>,
     {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         snapshot(&mut edited, tag);
         let project = edited.project.as_mut().ok_or("no recording")?;
         f(project)
@@ -1622,7 +1632,7 @@ impl Session {
 
     /// Revert the most recent edit. Returns `false` if there is nothing to undo.
     pub fn undo(&self) -> Result<bool, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let Some((_, prev)) = edited.undo.pop() else {
             return Ok(false);
         };
@@ -1635,7 +1645,7 @@ impl Session {
 
     /// Re-apply the most recently undone edit. Returns `false` if there is nothing to redo.
     pub fn redo(&self) -> Result<bool, String> {
-        let mut edited = self.edited.lock().map_err(|_| "lock poisoned")?;
+        let mut edited = self.edited.lock().unwrap_or_else(|e| e.into_inner());
         let Some(next) = edited.redo.pop() else {
             return Ok(false);
         };
@@ -1663,17 +1673,27 @@ fn encode_sample_bytes(
 }
 
 /// Index of the stored frame whose timestamp is closest to `t` (metadata only — no disk).
-fn nearest_idx(store: &FrameStore, clock: Clock, start_qpc: i64, t: f64) -> Option<usize> {
-    store
-        .recs()
-        .iter()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| {
-            let da = (clock.seconds_between(start_qpc, a.qpc) - t).abs();
-            let db = (clock.seconds_between(start_qpc, b.qpc) - t).abs();
-            da.total_cmp(&db)
-        })
-        .map(|(i, _)| i)
+/// Index of the stored frame whose capture time is nearest `t` seconds from `start_qpc`.
+///
+/// Frames are stored in capture order — ascending QPC — and time is linear in QPC, so this
+/// binary-searches instead of scanning every frame. That matters during export, which calls
+/// it once per output frame: the old linear scan made export O(frames × output_frames).
+fn nearest_idx(recs: &[FrameRec], clock: Clock, start_qpc: i64, t: f64) -> Option<usize> {
+    if recs.is_empty() {
+        return None;
+    }
+    let target = start_qpc as f64 + t * clock.freq() as f64;
+    let hi = recs.partition_point(|r| (r.qpc as f64) < target);
+    if hi == 0 {
+        return Some(0);
+    }
+    if hi >= recs.len() {
+        return Some(recs.len() - 1);
+    }
+    let prev = hi - 1;
+    let d_prev = (recs[prev].qpc as f64 - target).abs();
+    let d_hi = (recs[hi].qpc as f64 - target).abs();
+    Some(if d_hi < d_prev { hi } else { prev })
 }
 
 /// Turn the raw key log into overlay-worthy taps: modifier chords (`Ctrl+Shift+P`) and
@@ -1823,4 +1843,39 @@ fn next_id(project: &Project) -> u32 {
 
 fn default_end(t: f64, duration: f64) -> f64 {
     (t + 3.0).min(duration.max(t + 0.5))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(qpc: i64) -> FrameRec {
+        FrameRec {
+            qpc,
+            w: 2,
+            h: 2,
+            offset: 0,
+            len: 16,
+        }
+    }
+
+    #[test]
+    fn nearest_idx_picks_closest_frame_by_time() {
+        let clock = Clock::new();
+        let f = clock.freq();
+        let start = 1000;
+        // Frames captured 1s apart at t = 0, 1, 2, 3.
+        let recs: Vec<FrameRec> = (0..4i64).map(|i| rec(start + i * f)).collect();
+
+        assert_eq!(nearest_idx(&[], clock, start, 1.0), None);
+        // Exact hits.
+        assert_eq!(nearest_idx(&recs, clock, start, 0.0), Some(0));
+        assert_eq!(nearest_idx(&recs, clock, start, 2.0), Some(2));
+        // Out of range clamps to the ends.
+        assert_eq!(nearest_idx(&recs, clock, start, -5.0), Some(0));
+        assert_eq!(nearest_idx(&recs, clock, start, 99.0), Some(3));
+        // Rounds to the nearer neighbour.
+        assert_eq!(nearest_idx(&recs, clock, start, 1.4), Some(1));
+        assert_eq!(nearest_idx(&recs, clock, start, 1.6), Some(2));
+    }
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -204,10 +204,11 @@ impl Session {
             .as_ref()
             .map(|m| m.name.clone());
         let (rx, handle) = spawn_region(None, monitor);
-        let frame = rx
-            .recv_timeout(std::time::Duration::from_secs(3))
-            .map_err(|e| format!("screenshot capture failed: {e}"))?;
+        let frame = rx.recv_timeout(std::time::Duration::from_secs(3));
+        // Stop the capture thread on every path — including a timeout — so a slow or failed
+        // grab can't leak a live capture session and its GPU/duplication resources.
         handle.stop();
+        let frame = frame.map_err(|e| format!("screenshot capture failed: {e}"))?;
         let img = RgbaImage::new(frame.width, frame.height, swizzle_rb(&frame.bgra));
         let png = encode_png_to_vec(&img).map_err(|e| e.to_string())?;
         let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
@@ -561,11 +562,26 @@ impl Session {
 
         let encoder =
             crate::mp4::Mp4Encoder::new(Path::new(&out_path), enc_w, enc_h, fps, quality)?;
+        // Track the first frame error instead of `?`-ing out mid-stream, so a failure can
+        // delete the half-written file rather than leaving a corrupt .mp4 at the user's path.
+        let mut frame_err: Option<String> = None;
         for i in 0..total {
             let t_out = (i as f64 / f64::from(fps)).min(d_out);
             let t_src = t0 + output_to_source(t_out, span, &regions, &cuts);
-            let idx = nearest_idx(store, self.clock, edited.start_qpc, t_src).ok_or("no frames")?;
-            let frame = store.frame(idx)?;
+            let idx = match nearest_idx(store, self.clock, edited.start_qpc, t_src) {
+                Some(idx) => idx,
+                None => {
+                    frame_err = Some("no frames".into());
+                    break;
+                }
+            };
+            let frame = match store.frame(idx) {
+                Ok(frame) => frame,
+                Err(e) => {
+                    frame_err = Some(e);
+                    break;
+                }
+            };
             let scene = build_scene(project, track, out_w, out_h, t_src);
             let rgba = compositor.composite_scene(
                 &frame.bgra,
@@ -582,10 +598,20 @@ impl Session {
             } else {
                 img
             };
-            encoder.write_rgba(&img.pixels, img.width, img.height, i as u32)?;
+            if let Err(e) = encoder.write_rgba(&img.pixels, img.width, img.height, i as u32) {
+                frame_err = Some(e);
+                break;
+            }
             progress(i as u32 + 1, total as u32 + 1);
         }
-        encoder.finish()?;
+        let result = match frame_err {
+            Some(e) => Err(e),
+            None => encoder.finish(),
+        };
+        if result.is_err() {
+            let _ = std::fs::remove_file(&out_path);
+        }
+        result?;
         progress(total as u32 + 1, total as u32 + 1);
         Ok(())
     }

--- a/src/App.css
+++ b/src/App.css
@@ -1547,17 +1547,6 @@ kbd {
   background: var(--accent);
 }
 
-/* Snap guide — a dashed accent line that flashes where a dragged band catches. */
-.tl-snapguide {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 0;
-  border-left: 1px dashed var(--accent);
-  opacity: 0.85;
-  pointer-events: none;
-  z-index: 5;
-}
 .tl-playhead {
   position: absolute;
   top: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -1766,11 +1766,33 @@ kbd {
 }
 .welcome-actions {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: var(--sp-10);
 }
+/* Secondary "Skip" — quiet, so it doesn't compete with the CTA. */
+.welcome-skip {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--muted);
+}
+.welcome-skip:hover {
+  background: var(--panel-2);
+  color: var(--text);
+}
+/* Primary CTA — filled red, but the same height as Skip (no oversized type). */
 .welcome-cta {
-  margin-top: 0;
+  background: var(--record);
+  border-color: var(--record);
+  color: #fff;
+  font-weight: 600;
+}
+.welcome-cta:hover {
+  background: var(--record);
+  filter: brightness(1.08);
+}
+.welcome-cta .dot {
+  background: #fff;
 }
 /* Coachmark bubble pointing up at the Record button. */
 .coachmark {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -247,11 +247,9 @@ function App() {
   const [drag, setDrag] = createSignal<Drag>(null);
   const [stage, setStage] = createSignal({ w: 1, h: 1 });
   const [frameAspect, setFrameAspect] = createSignal(16 / 9);
-  // Pixel width of the timeline track surface — drives adaptive ruler ticks and the
-  // pixel-constant snap threshold (kept in sync via a ResizeObserver in onMount).
+  // Pixel width of the timeline track surface — drives the adaptive ruler ticks
+  // (kept in sync via a ResizeObserver in onMount).
   const [tlWidth, setTlWidth] = createSignal(800);
-  // While a timeline band is dragged, the time it snapped to (for the guide line), or null.
-  const [snapGuide, setSnapGuide] = createSignal<number | null>(null);
   // While an annotation is dragged on the canvas, the normalized x/y of an active
   // center/edge snap guide (or null). Drawn as crosshair lines on the overlay.
   const [snapX, setSnapX] = createSignal<number | null>(null);
@@ -1542,10 +1540,7 @@ function App() {
   };
   const onTrimMove = (e: PointerEvent) => {
     if (!trimDrag || !tlEl) return;
-    const raw = tlTime(e);
-    const hit = nearestTarget(raw, snapTargets({ kind: "trim" }));
-    setSnapGuide(hit);
-    const t = hit ?? raw;
+    const t = tlTime(e);
     const cur = trim() ?? { start: 0, end: duration() };
     const next =
       trimDrag === "start"
@@ -1556,7 +1551,6 @@ function App() {
     setTrimState(next);
   };
   const onTrimUp = async () => {
-    setSnapGuide(null);
     if (!trimDrag) return;
     trimDrag = null;
     const t = trim();
@@ -1612,12 +1606,10 @@ function App() {
     } else {
       end = Math.max(Math.min(duration(), end + dt), start + 0.2);
     }
-    ({ start, end } = snapBand(start, end, d.mode, snapTargets({ kind: "zoom", idx: d.idx }), 0.2));
     setZoomDrag({ ...d, cur: { start, end }, moved: d.moved || Math.abs(dt) > 0.02 });
   };
   const onZoomUp = async () => {
     const d = zoomDrag();
-    setSnapGuide(null);
     if (!d) return;
     setZoomDrag(null);
     setSelected(null);
@@ -1670,12 +1662,10 @@ function App() {
     } else {
       end = Math.max(Math.min(duration(), end + dt), start + 0.2);
     }
-    ({ start, end } = snapBand(start, end, d.mode, snapTargets({ kind: "speed", idx: d.idx }), 0.2));
     setSpeedDrag({ ...d, cur: { start, end }, moved: d.moved || Math.abs(dt) > 0.02 });
   };
   const onSpeedUp = async () => {
     const d = speedDrag();
-    setSnapGuide(null);
     if (!d) return;
     setSpeedDrag(null);
     setSelected(null);
@@ -1729,12 +1719,10 @@ function App() {
     } else {
       end = Math.max(Math.min(duration(), end + dt), start + 0.1);
     }
-    ({ start, end } = snapBand(start, end, d.mode, snapTargets({ kind: "cut", idx: d.idx }), 0.1));
     setCutDrag({ ...d, cur: { start, end }, moved: d.moved || Math.abs(dt) > 0.02 });
   };
   const onCutUp = async () => {
     const d = cutDrag();
-    setSnapGuide(null);
     if (!d) return;
     setCutDrag(null);
     setSelected(null);
@@ -1784,82 +1772,6 @@ function App() {
     return out;
   };
 
-  // ── timeline snapping (pixel-constant, zoom-independent) ────────────────────────
-  // A dragged band's edges snap to the playhead, the clip bounds, major ruler ticks, and
-  // every other band's edges — within ~8px regardless of clip length — and a guide line
-  // flashes at the catch point.
-  const snapThresholdT = () => 8 / Math.max(pxPerSec(), 1e-6);
-  const snapTargets = (exclude?: {
-    kind: "zoom" | "speed" | "cut" | "ann" | "trim";
-    idx?: number;
-    id?: number;
-  }): number[] => {
-    const ts: number[] = [0, duration(), playhead()];
-    for (const m of tickMarks()) if (m.major) ts.push(m.t);
-    zooms().forEach((z, i) => {
-      if (!(exclude?.kind === "zoom" && exclude.idx === i)) ts.push(z.start, z.end);
-    });
-    speed().forEach((r, i) => {
-      if (!(exclude?.kind === "speed" && exclude.idx === i)) ts.push(r.start, r.end);
-    });
-    cuts().forEach((c, i) => {
-      if (!(exclude?.kind === "cut" && exclude.idx === i)) ts.push(c.start, c.end);
-    });
-    annBars().forEach((b) => {
-      if (!(exclude?.kind === "ann" && exclude.id === b.id)) ts.push(b.start, b.end);
-    });
-    return ts;
-  };
-  const nearestTarget = (t: number, targets: number[]): number | null => {
-    let hit: number | null = null;
-    let bestD = snapThresholdT();
-    for (const tg of targets) {
-      const dd = Math.abs(t - tg);
-      if (dd <= bestD) {
-        bestD = dd;
-        hit = tg;
-      }
-    }
-    return hit;
-  };
-  // Snap a dragged band for the given mode; updates the guide and returns the new band.
-  const snapBand = (
-    start: number,
-    end: number,
-    mode: "move" | "l" | "r",
-    targets: number[],
-    minGap: number,
-  ): { start: number; end: number } => {
-    const d = duration();
-    if (mode === "l") {
-      const hit = nearestTarget(start, targets);
-      const v = hit === null ? start : Math.min(Math.max(0, hit), end - minGap);
-      setSnapGuide(hit !== null && v === hit ? hit : null);
-      return { start: v, end };
-    }
-    if (mode === "r") {
-      const hit = nearestTarget(end, targets);
-      const v = hit === null ? end : Math.max(Math.min(d, hit), start + minGap);
-      setSnapGuide(hit !== null && v === hit ? hit : null);
-      return { start, end: v };
-    }
-    // move: snap whichever edge lands closest to a target, shifting the whole band.
-    const hs = nearestTarget(start, targets);
-    const he = nearestTarget(end, targets);
-    const ds = hs !== null ? Math.abs(start - hs) : Infinity;
-    const de = he !== null ? Math.abs(end - he) : Infinity;
-    const len = end - start;
-    if (ds <= de && hs !== null && hs >= 0 && hs + len <= d) {
-      setSnapGuide(hs);
-      return { start: hs, end: hs + len };
-    }
-    if (he !== null && he - len >= 0 && he <= d) {
-      setSnapGuide(he);
-      return { start: he - len, end: he };
-    }
-    setSnapGuide(null);
-    return { start, end };
-  };
   // Annotation bar dragging: grab the middle to move it in time, the edges to resize
   // how long it stays on screen.
   const [annDrag, setAnnDrag] = createSignal<{
@@ -1904,12 +1816,10 @@ function App() {
     } else {
       end = Math.max(Math.min(duration(), end + dt), start + 0.2);
     }
-    ({ start, end } = snapBand(start, end, d.mode, snapTargets({ kind: "ann", id: d.id }), 0.2));
     setAnnDrag({ ...d, cur: { start, end }, moved: d.moved || Math.abs(dt) > 0.02 });
   };
   const onAnnUp = async () => {
     const d = annDrag();
-    setSnapGuide(null);
     if (!d) return;
     setAnnDrag(null);
     setSelZoom(null);
@@ -3197,10 +3107,6 @@ function App() {
             <div class="tl-playhead" style={{ left: `${pct(playhead())}%` }}>
               <i />
             </div>
-
-            <Show when={snapGuide() !== null}>
-              <div class="tl-snapguide" style={{ left: `${pct(snapGuide()!)}%` }} />
-            </Show>
           </Show>
         </div>
       </footer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1051,6 +1051,14 @@ function App() {
     const s = selected();
     return s?.kind === "arrow" ? anns().arrows.find((a) => a.id === s.id) : undefined;
   };
+  // The inspector "Content" field is seeded from the model only while it is NOT focused, so
+  // the async edit→refresh round-trip can't reset the caret to the end mid-typing.
+  let contentInput: HTMLInputElement | undefined;
+  createEffect(() => {
+    const t = selectedText();
+    const el = contentInput;
+    if (el && t && document.activeElement !== el) el.value = t.text;
+  });
   const editStyle = async (patch: { thickness?: number; filled?: boolean }) => {
     const s = selected();
     if (!s) return;
@@ -1238,13 +1246,13 @@ function App() {
     setCoachRecord(false);
     try {
       setStatus("Choose the area to record…");
-      await invoke("enter_overlay"); // hide editor from capture + go fullscreen
       setBackdrop(null);
       setRecordPhase("active"); // overlay shows immediately (dark + presets)
-      // Freeze the desktop behind us as a backdrop to draw on (non-blocking).
-      invoke<string>("screenshot")
-        .then(setBackdrop)
-        .catch(() => setBackdrop(null));
+      // enter_overlay hides the editor, grabs the desktop as the selector backdrop, then
+      // brings the window back fullscreen + excluded from capture. It returns the frozen
+      // desktop as a data-URL (empty string if the grab failed → dark canvas fallback).
+      const shot = await invoke<string>("enter_overlay");
+      setBackdrop(shot || null);
     } catch (e) {
       setRecordPhase("idle");
       setStatus(`Error: ${String(e)}`);
@@ -2430,7 +2438,7 @@ function App() {
                     class="insp-text-input"
                     type="text"
                     spellcheck={false}
-                    value={selectedText()!.text}
+                    ref={(el) => (contentInput = el)}
                     onInput={(e) => void editText(e.currentTarget.value)}
                   />
                 </InspRow>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1977,8 +1977,12 @@ function App() {
       /* storage unavailable */
     }
   };
-  const inspectorOpen = () =>
+  const somethingSelected = () =>
     !!selected() || selZoom() !== null || selSpeed() !== null || selCut() !== null;
+  // A drawing tool is armed (not Select). We reserve the inspector column for it so the
+  // canvas doesn't reflow the moment you place an element (which would jump the editor box).
+  const drawingToolActive = () => hasClip() && tool() !== "select";
+  const inspectorOpen = () => somethingSelected() || drawingToolActive();
 
   const safeName = () =>
     projectName().replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "vuoom";
@@ -2460,21 +2464,29 @@ function App() {
 
               <Show when={editingTextAnn()}>
                 {(() => {
-                  const ta = editingTextAnn()!;
-                  const p = px({ x: v2(ta.pos).x, y: v2(ta.pos).y });
-                  const fs = ta.font_size * stage().h;
+                  const id = editingText()!;
+                  // Reactive accessors so the editor box tracks the label as the canvas
+                  // resizes (e.g. when the inspector opens). The value stays uncontrolled
+                  // (seeded once) so typing never resets the caret.
+                  const live = () => anns().texts.find((t) => t.id === id);
+                  const initial = live()?.text ?? "";
+                  const p = () => {
+                    const t = live();
+                    return t ? px({ x: v2(t.pos).x, y: v2(t.pos).y }) : { x: 0, y: 0 };
+                  };
+                  const fs = () => (live()?.font_size ?? 0.05) * stage().h;
                   return (
                     <input
                       class="text-edit"
                       style={{
-                        left: `${p.x}px`,
-                        top: `${p.y}px`,
-                        "font-size": `${fs}px`,
-                        "font-family": fontCss(ta.font),
-                        "font-weight": ta.bold ? "700" : "400",
-                        "font-style": ta.italic ? "italic" : "normal",
+                        left: `${p().x}px`,
+                        top: `${p().y}px`,
+                        "font-size": `${fs()}px`,
+                        "font-family": fontCss(live()?.font ?? ""),
+                        "font-weight": live()?.bold ? "700" : "400",
+                        "font-style": live()?.italic ? "italic" : "normal",
                       }}
-                      value={ta.text}
+                      value={initial}
                       spellcheck={false}
                       ref={(el) => queueMicrotask(() => { el.focus(); el.select(); })}
                       onInput={(e) => editTextLive(e.currentTarget.value)}
@@ -2849,6 +2861,21 @@ function App() {
             </button>
           </InspectorPanel>
         </Show>
+
+        {/* Tool-context panel: holds the inspector column while a drawing tool is armed
+            (nothing selected yet) so placing an element never reflows the canvas. */}
+        <Show when={drawingToolActive() && !somethingSelected()}>
+          <aside class="properties">
+            <div class="inspector-head">
+              <h2>{TOOLS.find((t) => t.id === tool())?.label}</h2>
+            </div>
+            <p class="muted small">{TOOLS.find((t) => t.id === tool())?.hint}</p>
+            <p class="muted small">
+              Press <kbd>V</kbd> for Select, or pick another tool on the left. Its options appear
+              here once you place an element.
+            </p>
+          </aside>
+        </Show>
       </div>
 
       <footer class="timeline">
@@ -3207,15 +3234,15 @@ function App() {
             <LogoWordmark />
             <h2 class="welcome-title">Record. Auto-zoom. Ship.</h2>
             <p class="welcome-sub">
-              Vuoom records your screen, zooms in where you click, and exports a crisp GIF or
-              MP4 — ready for your README, Slack, or socials.
+              Record your screen, auto-zoom where you click, and export a crisp GIF or MP4 for
+              your README, Slack, or socials.
             </p>
             <div class="welcome-steps">
               <div class="welcome-step">
                 <span class="welcome-num">1</span>
                 <div>
                   <strong>Record</strong>
-                  <small>Pick an area and hit record — your clicks drive cinematic zooms.</small>
+                  <small>Pick an area and hit record. Your clicks drive the zoom.</small>
                 </div>
               </div>
               <div class="welcome-step">
@@ -3234,11 +3261,11 @@ function App() {
               </div>
             </div>
             <div class="welcome-actions">
-              <button class="btn" onClick={() => dismissWelcome(true)}>
-                Maybe later
+              <button class="btn welcome-skip" onClick={() => dismissWelcome(true)}>
+                Skip
               </button>
               <button
-                class="btn record cta welcome-cta"
+                class="btn record welcome-cta"
                 onClick={() => {
                   dismissWelcome(false);
                   void startRecord();
@@ -3256,7 +3283,7 @@ function App() {
         <div class="coachmark" style={{ left: `${coachPos().x}px`, top: `${coachPos().y + 10}px` }}>
           <span class="coach-arrow" />
           <p>
-            Start here — or press <kbd>Ctrl+Shift+R</kbd> any time.
+            Click to start, or press <kbd>Ctrl+Shift+R</kbd> any time.
           </p>
           <button class="btn ghost coach-dismiss" onClick={() => setCoachRecord(false)}>
             Got it

--- a/src/RecordOverlay.tsx
+++ b/src/RecordOverlay.tsx
@@ -59,7 +59,13 @@ export default function RecordOverlay(props: {
   const [paused, setPaused] = createSignal(false);
   let start: { x: number; y: number } | null = null;
   let elapsedTimer: number | undefined;
+  let countTimer: number | undefined;
   let startMs = 0;
+
+  const clearCountdown = () => {
+    if (countTimer) clearTimeout(countTimer);
+    countTimer = undefined;
+  };
 
   // Live "director's monitor": the backend streams a zoom-tracked preview to this canvas.
   const preview = new PreviewClient();
@@ -71,6 +77,7 @@ export default function RecordOverlay(props: {
   };
 
   const cancel = () => {
+    clearCountdown();
     stopTimer();
     void invoke("cancel_record_flow").finally(() => props.onCancel());
   };
@@ -96,16 +103,19 @@ export default function RecordOverlay(props: {
 
   const runCountdown = () => {
     const tick = () => {
+      countTimer = undefined;
+      // Cancelled (Cancel/Esc) during the 3-2-1: stop here, never start the recording.
+      if (phase() !== "countdown") return;
       const c = count() - 1;
       if (c <= 0) {
         setCount(0);
         void beginRecording();
       } else {
         setCount(c);
-        window.setTimeout(tick, 1000);
+        countTimer = window.setTimeout(tick, 1000);
       }
     };
-    window.setTimeout(tick, 1000);
+    countTimer = window.setTimeout(tick, 1000);
   };
 
   const beginRecording = async () => {
@@ -180,9 +190,13 @@ export default function RecordOverlay(props: {
   };
 
   const onKey = (e: KeyboardEvent) => {
+    // Esc aborts both while picking a region and during the 3-2-1 countdown.
+    if (e.key === "Escape" && (phase() === "select" || phase() === "countdown")) {
+      cancel();
+      return;
+    }
     if (phase() !== "select") return;
-    if (e.key === "Escape") cancel();
-    else if (e.key === "Enter") void beginCountdown();
+    if (e.key === "Enter") void beginCountdown();
   };
   onMount(() => {
     window.addEventListener("keydown", onKey);
@@ -194,6 +208,7 @@ export default function RecordOverlay(props: {
     onCleanup(() => {
       window.removeEventListener("keydown", onKey);
       void unlistenStop.then((un) => un());
+      clearCountdown();
       stopTimer();
       preview.disconnect();
     });

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -31,6 +31,9 @@ export class PreviewClient {
   private ctx: CanvasRenderingContext2D | null = null;
   private aspect = 0;
   private onAspect: ((aspect: number) => void) | null = null;
+  private port = 0;
+  private reconnectTimer: number | undefined;
+  private closed = true; // true once disconnect() is called — suppresses reconnects
 
   /** Bind the canvas frames will be drawn into. */
   attach(canvas: HTMLCanvasElement): void {
@@ -44,21 +47,64 @@ export class PreviewClient {
     this.onAspect = cb;
   }
 
-  /** Connect to the engine's preview server on `port` (from the Rust side). */
+  /** Connect to the engine's preview server on `port` (from the Rust side). The socket
+   *  auto-reconnects with a short backoff if the engine drops it, until `disconnect()`. */
   connect(port: number): void {
     this.disconnect();
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    this.port = port;
+    this.closed = false;
+    this.open();
+  }
+
+  private open(): void {
+    this.closeSocket();
+    const ws = new WebSocket(`ws://127.0.0.1:${this.port}`);
     ws.binaryType = "arraybuffer";
     ws.onmessage = (ev) => {
       if (ev.data instanceof ArrayBuffer) this.draw(ev.data);
     };
+    ws.onclose = () => this.scheduleReconnect();
+    ws.onerror = () => {
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    };
     this.ws = ws;
   }
 
-  /** Close the connection. */
+  private scheduleReconnect(): void {
+    if (this.closed || this.reconnectTimer !== undefined || !this.port) return;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (!this.closed) this.open();
+    }, 1000);
+  }
+
+  private closeSocket(): void {
+    const ws = this.ws;
+    if (ws) {
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+      this.ws = null;
+    }
+  }
+
+  /** Close the connection and stop reconnecting. */
   disconnect(): void {
-    this.ws?.close();
-    this.ws = null;
+    this.closed = true;
+    if (this.reconnectTimer !== undefined) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.closeSocket();
   }
 
   private draw(buf: ArrayBuffer): void {


### PR DESCRIPTION
Audit follow-ups. Locally verified: tsc, vite build, cargo fmt --check, clippy -D warnings, full workspace tests — all green.

## Fixes
- **Win11 blank region-selector backdrop** (the reported bug): a fullscreen `WDA_EXCLUDEFROMCAPTURE` window is captured as black on Win11 (direct-flip path). `enter_overlay` now hides the editor, grabs the clean desktop, then returns fullscreen+excluded.
- **engine guards**: clamp spring half-life + fps (no NaN-poisoned camera track); reject 0×0 GIF frames (was a quantizer panic); clamp gifski `--quality`/gifsicle `--lossy`. +unit tests.
- **session robustness**: stop the screenshot capture thread on timeout (leak); delete the half-written .mp4 on export error.
- **UI**: cancelling during the 3-2-1 countdown no longer starts an orphan recording; preview websocket auto-reconnects on engine drop; inspector "Content" field no longer jumps the caret while typing.
- **chore**: correct repository URL; sync Cargo.lock version.

⚠️ Runtime-only checks left for a real machine: the Win11 backdrop grab and GPU compositor paths (CI has no GPU/display).